### PR TITLE
Fix setup.sh bootstrap: drop untrusted jsonschema tap, update yek hos…

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -4,7 +4,6 @@ tap "homebrew/bundle"
 tap "homebrew/services"
 tap "oven-sh/bun"
 tap "shopify/shopify"
-tap "sourcemeta/apps"
 # Run your GitHub Actions locally
 brew "act"
 # GNU compiler collection
@@ -222,8 +221,6 @@ cask "gimp"
 cask "google-chrome"
 # Terminal emulator as alternative to Apple's Terminal app
 cask "iterm2"
-# The CLI for working with JSON Schema
-cask "sourcemeta/apps/jsonschema"
 # Minimal installer for conda
 cask "miniconda"
 # Tool to control external monitor brightness & volume

--- a/setup.sh
+++ b/setup.sh
@@ -137,6 +137,10 @@ if command -v mise &>/dev/null; then
   if brew list openssl@3 &>/dev/null; then
     export RUBY_CONFIGURE_OPTS="--with-openssl-dir=$(brew --prefix openssl@3)"
   fi
+  # Honor idiomatic version files (.ruby-version / .node-version / .nvmrc /
+  # .python-version). Modern mise ignores these by default — without this,
+  # `cd` into a project with a .ruby-version would NOT auto-switch ruby.
+  mise settings idiomatic_version_file_enable_tools=ruby,node,python
   # Pin global defaults; per-project versions come from .ruby-version /
   # .node-version / .python-version files plus `mise use` + direnv.
   # ruby@latest / python@latest = newest *stable* release (not nightly);
@@ -239,7 +243,8 @@ fi
 echo "Checking for yek..."
 if ! command -v yek &>/dev/null; then
   echo "Installing yek..."
-  curl -fsSL https://bodo.run/yek.sh | bash
+  curl -fsSL https://azimi.me/yek.sh | bash \
+    || echo "yek: install failed (host unreachable?); skipping — install later from https://github.com/mohsen1/yek"
 else
   echo "yek already installed"
 fi


### PR DESCRIPTION
- Brewfile: remove sourcemeta/apps tap + jsonschema cask. Newer Homebrew refuses untrusted third-party tap casks, which aborted `brew bundle` under `set -e`.
- setup.sh: yek installer host bodo.run is dead (NXDOMAIN). Switch to azimi.me/yek.sh and make it non-fatal so an unreachable host no longer aborts the whole bootstrap.
- setup.sh: enable mise idiomatic_version_file_enable_tools=ruby,node,python. Modern mise ignores .ruby-version/.node-version/.python-version by default, so per-project auto-switching wasn't actually working.