### PR TITLE
Port dotfiles setup to Ubuntu 24.04 (headless server)

### DIFF
--- a/CHEATSHEET-ubuntu.md
+++ b/CHEATSHEET-ubuntu.md
@@ -1,0 +1,138 @@
+# Ubuntu Workflow Cheatsheet
+
+Deltas from `CHEATSHEET.md` for the headless Ubuntu server. Everything in the
+main cheatsheet still applies — tmux prefix is `Ctrl-a`, Vim leader is `,` —
+this file only covers what is *different* when you're SSHed into the box.
+
+---
+
+## Clipboard — the big one
+
+There is no `pbcopy` and no X server here. Copying travels to your Mac as an
+**OSC 52 escape sequence**, which tmux emits and iTerm2 turns into a real
+pasteboard write.
+
+**One-time setup on the Mac:**
+iTerm2 → Settings → General → **Selection** tab →
+☑ *"Applications in terminal may access clipboard"*
+
+Without that checkbox everything below silently does nothing.
+
+| Where | Key | Result |
+|---|---|---|
+| tmux copy-mode | `y` or `Enter` after a selection | ⌘V on the Mac pastes it |
+| tmux, mouse | drag-select in a pane | ⌘V pastes it (stays in copy mode) |
+| Vim | `vv` (or `3vv`) | ⌘V pastes those lines |
+| Vim | `,y` + motion, `,yy`, or `,y` in visual mode | ⌘V pastes the motion/selection |
+| Vim | `yy` | buffer register only — **not** the Mac clipboard |
+
+Notes:
+- `vv` also leaves the text in Vim's unnamed register, so `p` still works locally.
+- Anything OSC-52-copied inside tmux also becomes a tmux paste buffer, so
+  `C-a P` pastes it into another pane.
+- **GNU screen swallows OSC 52** — `screen-256color` has no `Ms` capability.
+  Use tmux when you want to copy out. `screenrc` is still symlinked for muscle
+  memory.
+- Option-drag in iTerm2 still bypasses mouse reporting for a plain local
+  selection — useful across panes or inside a pager.
+
+---
+
+## Auto-attach on SSH
+
+SSHing in drops you straight into a tmux session named `main` (attaching if it
+already exists). Detaching with `C-a d` ends the SSH session.
+
+To get in **without** tmux:
+
+```bash
+ssh ghost -t /bin/bash     # skips zsh entirely — also the recovery path
+NO_TMUX=1 ssh ghost        # only works if sshd has AcceptEnv NO_TMUX
+```
+
+The auto-attach never fires for non-interactive shells, `ssh host <cmd>`,
+scp/rsync/sftp, panes already inside tmux, or Claude Code's Bash tool.
+
+---
+
+## `newrc` — Claude Code remote-control sessions
+
+Linux-only. Creates a project directory, marks it trusted in `~/.claude.json`,
+and enables a systemd user unit that runs `claude remote-control` in a detached
+tmux server.
+
+```bash
+newrc myproject                              # empty directory
+newrc myproject git@github.com:me/repo.git   # clone first
+
+systemctl --user status  claude-rc@myproject
+systemctl --user restart claude-rc@myproject
+systemctl --user disable --now claude-rc@myproject
+
+tmux -L cc-myproject attach                  # look inside the session
+```
+
+Projects live in `~/workspaces/claude-rc-projects/<name>`. Lingering is enabled,
+so the units survive logout.
+
+---
+
+## Command differences from macOS
+
+| macOS | Ubuntu | Why |
+|---|---|---|
+| `bat` | `bat` (via a shim) | Debian ships it as `batcat`; `~/.local/bin/bat` symlinks it |
+| `fd` | `fd` (via a shim) | Debian ships it as `fdfind`; same treatment |
+| `brew install x` | `sudo apt install x` | add it to `aptfile-ubuntu` to make it permanent |
+| `brew bundle` | `./setup-ubuntu.sh` | re-runs apt against `aptfile-ubuntu` |
+| `update_brewfile` | *(gone)* | no Homebrew here |
+| `pbcopy` / `pbpaste` | *(gone)* | see Clipboard above |
+| `open .` | *(gone)* | headless |
+
+`ls`, `top`, `date`, and `grep --exclude-dir` are GNU here. The aliases already
+account for it — `ls` is `--color=auto`, `top` is `-o %CPU`.
+
+---
+
+## Runtimes
+
+`mise` manages ruby, python and node; `direnv` handles per-project env.
+
+```bash
+mise ls                    # what's installed
+mise use -g node@22        # change the global default
+mise use node@20           # pin for this project (writes .mise.toml)
+```
+
+`.ruby-version` / `.node-version` / `.python-version` files are honoured.
+
+**Don't `pip install` into the system python** — Ubuntu 24.04 is PEP 668
+externally-managed and will refuse. Use a mise-managed python, a venv (`ae` /
+`de`), or `pipx` for CLI tools.
+
+For Ruby projects, the `PATH_add bin` direnv trick from `CLAUDE.user.md` works
+the same way here.
+
+---
+
+## Things that are intentionally absent
+
+- **AI commit messages.** `core.hooksPath` is not set in `gitconfig-ubuntu`, so
+  `git commit` opens a plain editor. To enable it: add `hooksPath = ~/.git-hooks`
+  to `gitconfig-ubuntu`, then symlink `git_hooks/prepare-commit-msg` into
+  `~/.git-hooks/` and put a real key in `~/.keys/openai`.
+- **Neovim.** `init.vim` is in the repo but has never been linked by either
+  setup script.
+- **Everything GUI** — iTerm2 prefs, casks, Mac App Store apps.
+
+---
+
+## Recovery
+
+```bash
+ssh ghost -t /bin/bash        # get a shell if zsh is broken
+chsh -s /bin/bash             # put the login shell back
+
+ls ~/.dotfiles-backup/        # every file setup-ubuntu.sh replaced, per run
+cat ~/.dotfiles-backup/<timestamp>/setup.log
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,8 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Personal macOS dotfiles and system configuration for a developer machine. All config files are **symlinked** from this repo to the home directory by `setup.sh` — edits here are immediately live (no copy/sync step needed).
 
+There is also an **Ubuntu port** for headless servers, driven by `setup-ubuntu.sh` + `aptfile-ubuntu`. It is strictly additive: files that needed changing have a `-ubuntu` sibling, and the macOS originals are never modified. See "Ubuntu Port" below before touching anything with a `-ubuntu` suffix.
+
 ## Applying Changes by Type
 
 | Change type | How it takes effect |
@@ -16,6 +18,8 @@ Personal macOS dotfiles and system configuration for a developer machine. All co
 | `setup.sh` Vim plugin list (`VIM_PACKAGES` array) | Run `setup.sh` again, or manually: `git clone <url> ~/.vim/pack/vendor/start/<name>` |
 | `git_hooks/prepare-commit-msg` | Immediately via symlink at `~/.git-hooks/` |
 | `claude/settings.json`, `claude/statusline-command.sh`, `CLAUDE.user.md` | Immediately via symlink into `~/.claude/`; restart Claude Code to pick up `settings.json` changes |
+| `*-ubuntu` files (`zshrc-ubuntu`, `vimrc-ubuntu`, …) | Immediately via symlink on an Ubuntu box; `source ~/.zshrc` to reload. **macOS never reads these.** |
+| `aptfile-ubuntu` — add or remove packages | Run `./setup-ubuntu.sh` again (it re-runs apt), or just `sudo apt install <pkg>`. Removal is manual — there is no `brew bundle cleanup` equivalent |
 | `iterm2/com.googlecode.iterm2.plist` | Not symlinked — iTerm2 reads/writes this file directly (Preferences > General > "Load preferences from a custom folder or URL", wired up by `setup.sh`). Edit via the iTerm2 GUI as normal; changes autosave into this file, then `git diff`/commit it. **Quit iTerm2 first** before hand-editing this file or running `defaults write com.googlecode.iterm2 ...` — iTerm2 holds the whole domain in memory and overwrites the file wholesale on its next save/quit |
 
 ## Key Conventions
@@ -27,6 +31,32 @@ Personal macOS dotfiles and system configuration for a developer machine. All co
 - **Global git hooks**: Configured via `gitconfig` (`hooksPath = ~/.git-hooks`). The `prepare-commit-msg` hook uses `OPENAI_API_KEY` (from `~/.keys/openai`) to auto-generate conventional commit messages.
 - **Claude config**: Only the portable config files are checked in (`claude/settings.json`, `claude/statusline-command.sh`, `CLAUDE.user.md`), symlinked individually into `~/.claude/`. Do **not** symlink the whole `~/.claude/` directory — it also holds conversation transcripts (`projects/`), `history.jsonl`, plugins, caches, and credentials, none of which belong in a published repo. Machine-local overrides go in `~/.claude/settings.local.json` (untracked).
 - **iTerm2 config**: Profiles, keybindings, hotkey-window bindings, and color schemes live in `iterm2/com.googlecode.iterm2.plist`, loaded via iTerm2's own "custom preferences folder" feature rather than a symlink. `setup.sh` points iTerm2 at that folder (skipped if iTerm2 is currently running, since it caches prefs in memory). To edit: quit iTerm2 if it's running, make the change, relaunch — never edit the plist while iTerm2 is open.
+
+## Ubuntu Port
+
+Tested on Ubuntu 24.04 "noble", x86_64, headless. Entrypoint is `setup-ubuntu.sh` (`setup.sh` now refuses to run on non-Darwin and points at it).
+
+**Rule: never edit a macOS file to make Ubuntu work.** If a config needs to differ, add or update the `-ubuntu` sibling. If a change is portable, make it in *both* files and say so in the commit.
+
+| Ubuntu-only file | Notes |
+|---|---|
+| `setup-ubuntu.sh` | apt instead of Homebrew. Phases are individually fail-soft; only "not Linux", "running as root", "repo missing", "sudo failed" and "zsh/git/curl absent after apt" abort the run |
+| `aptfile-ubuntu` | The `Brewfile` analogue. One package per line, `#` comments. Names are filtered through `apt-cache show` before install so one bad name can't sink the batch |
+| `zshrc-ubuntu` | GNU vs BSD commands (`ls --color=auto`, `top -o %CPU`, `date +%s`, basename-only `--exclude-dir`); no `/opt/homebrew` or `/Applications` on PATH; every `eval "$(x init …)"` is guarded with `command -v` because this file is the login shell; tmux auto-attach on SSH |
+| `vimrc-ubuntu` | Headless vim has no `+clipboard`, so copy goes over **OSC 52** via the `vim-oscyank` plugin. Vim 9.1 in noble has no native OSC 52 and never will (LTS doesn't rebase vim) |
+| `tmux.conf-ubuntu` | `pbcopy` → OSC 52. `set -g set-clipboard on` is load-bearing: tmux only forwards an application's OSC 52 when the value is exactly `on`, not `external` |
+| `gitconfig-ubuntu` | Identical minus `core.hooksPath` — the AI `prepare-commit-msg` hook is deliberately not installed on the server |
+| `claude/settings-ubuntu.json` | `$HOME`-relative statusline path (the macOS one hardcodes `/Users/john/…`) plus `autoUpdatesChannel` |
+| `bin/newrc`, `systemd/claude-rc@.service` | Linux-only. `newrc <name> [git-url]` creates a project under `~/workspaces/claude-rc-projects/` and enables a `claude remote-control` systemd user unit for it |
+| `CHEATSHEET-ubuntu.md` | Ubuntu deltas to `CHEATSHEET.md` |
+
+Not ported: `Brewfile`, `Brewfile.mas`, `iterm2/`, `iTerm2 State.itermexport`, `git_hooks/prepare-commit-msg`, `init.vim` (vestigial — `setup.sh` never linked it).
+
+**Path convention differs:** macOS uses `~/workspace/system_files` (singular), the Ubuntu box uses `~/workspaces/system_files` (**plural**). `zshrc-ubuntu` sets `SYSTEM_FILES_DIR` accordingly.
+
+**Never run `git lfs install` on the server** — `~/.gitconfig` is a symlink into this repo, so it would dirty the working tree. The lfs filter is already in `gitconfig-ubuntu`.
+
+**Not available via apt**, installed separately by `setup-ubuntu.sh`: `mise` and `ngrok` (official signed apt repos), `starship` (`install.sh` into `~/.local/bin`), `zsh-fast-syntax-highlighting` (git clone into `~/.zsh`), `pnpm` (corepack, after mise installs node).
 
 ## setup.sh
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 
 
 
-this is my setup for terminals.  Tested only in OS X.
+this is my setup for terminals.  Primarily OS X; there is also an Ubuntu port
+for headless servers — see "Quick Setup for a New Ubuntu Server" below.
 
 The color scheme is based off of ir_black from infinitered
 http://blog.infinitered.com
@@ -34,6 +35,72 @@ less setup.sh
 chmod +x setup.sh
 ./setup.sh
 ```
+
+# Quick Setup for a New Ubuntu Server
+
+`setup.sh` is macOS-only (Homebrew, `xcode-select`, `defaults`, mas). On Ubuntu
+use `setup-ubuntu.sh`, which does the same job with apt. Tested on Ubuntu 24.04
+"noble", x86_64, headless.
+
+```bash
+git clone https://github.com/softwaregravy/system_files.git ~/workspaces/system_files
+cd ~/workspaces/system_files
+
+# Run it from a detached tmux/screen session — it takes ~10 minutes and a
+# mid-dpkg kill leaves apt half-configured.
+tmux new -s setup
+./setup-ubuntu.sh
+```
+
+Flags: `--yes` (never prompt), `--skip-apt` (symlinks only), `--no-chsh` (don't
+change the login shell), `--help`.
+
+## How the Ubuntu port is organised
+
+Config files that are already portable are symlinked straight from this repo and
+shared with the Mac. Files that needed real changes have a `-ubuntu` sibling; the
+macOS original is never modified.
+
+| Ubuntu file | Why it differs from the macOS original |
+|---|---|
+| `zshrc-ubuntu` | No Homebrew; GNU instead of BSD `ls`/`top`/`date`/`grep`; Linux paths; guarded `eval`s; tmux auto-attach on SSH |
+| `vimrc-ubuntu` | OSC 52 clipboard (headless vim has no `+clipboard`) via the vim-oscyank plugin |
+| `tmux.conf-ubuntu` | Copy goes over OSC 52 instead of `pbcopy` |
+| `gitconfig-ubuntu` | No `core.hooksPath` — the AI `prepare-commit-msg` hook is not installed here |
+| `claude/settings-ubuntu.json` | `$HOME`-relative statusline path; keeps `autoUpdatesChannel` |
+| `aptfile-ubuntu` | The `Brewfile` equivalent — one apt package per line |
+| `bin/newrc`, `systemd/claude-rc@.service` | Linux-only; spin up a `claude remote-control` session under systemd |
+
+Shared unchanged: `screenrc`, `inputrc`, `irbrc`, `gemrc`, `npmrc`,
+`starship.toml`, `ir_black.vim`, `vim/after/syntax/sh.vim`, `CLAUDE.user.md`,
+`claude/statusline-command.sh`, `ngrok.yml` (linked to `~/.config/ngrok/` rather
+than `~/Library/Application Support/`).
+
+## Clipboard over SSH
+
+Copying in tmux or vim on the server reaches your local macOS clipboard via OSC
+52 escape sequences. Enable it once in iTerm2:
+
+**Settings → General → Selection → "Applications in terminal may access clipboard"**
+
+Then `y` in tmux copy-mode and `vv` in vim both land in your Mac's pasteboard.
+
+## Notes
+
+- Four things have no apt package and are installed separately by the script:
+  **mise** and **ngrok** (official signed apt repos), **starship** (`install.sh`
+  into `~/.local/bin`), **fast-syntax-highlighting** (git clone into `~/.zsh`).
+  **pnpm** comes from corepack once mise has installed node.
+- `bat` and `fd-find` install as `batcat`/`fdfind` on Debian/Ubuntu because of
+  filename clashes; the script symlinks them to `bat`/`fd` in `~/.local/bin`.
+- `gh` comes from Ubuntu universe (2.45.0), which trails upstream by a fair way.
+  If you need newer, add GitHub's own apt repo.
+- Runtimes come from mise (`node@lts`, `python@latest`, `ruby@latest`). mise
+  prefers precompiled builds; the `-dev` packages in `aptfile-ubuntu` are there
+  for the source-compile fallback.
+- Anything the script replaces in `$HOME` is moved to
+  `~/.dotfiles-backup/<timestamp>/`, along with the full run log.
+- See `CHEATSHEET-ubuntu.md` for the Ubuntu-specific keybindings and differences.
 
 
 

--- a/aptfile-ubuntu
+++ b/aptfile-ubuntu
@@ -1,0 +1,300 @@
+# aptfile-ubuntu — the Brewfile analogue for Ubuntu (24.04 noble, headless server)
+#
+# WHAT THIS IS
+#   A plain list of apt package names, one per line. This is to `setup-ubuntu.sh`
+#   what `Brewfile` is to `brew bundle` on the Mac. It is NOT a shell script and
+#   NOT the Brewfile format — no `brew "x"` quoting, just bare package names.
+#
+# HOW IT IS CONSUMED
+#   `setup-ubuntu.sh` reads this file, strips comments and blank lines, drops any
+#   name that isn't available in the configured apt sources, and passes everything
+#   that's left to a single `apt-get install`.
+#   Its reader is `sed -e 's/#.*//' -e 's/[[:space:]]//g'`, so a `#` starts a
+#   comment ANYWHERE on the line: a whole-line `# note` and a trailing
+#   `pkgname  # note` both work, and surrounding whitespace is discarded. One
+#   package name per line regardless — the reader never splits on spaces, so two
+#   names on one line would be glued into a single bogus token.
+#
+# HOW TO ADD A PACKAGE
+#   1. Add the bare package name on its own line, in the right section.
+#   2. Either re-run `setup-ubuntu.sh` (idempotent, already-installed packages
+#      are a no-op), or just `sudo apt install <pkg>` and add the line so the
+#      next machine picks it up too.
+#   Check a name exists first with `apt-cache policy <pkg>` — make sure it prints
+#   a real Candidate and not "(none)", which means the name is only a virtual
+#   alias (see the STALE-DOC note further down). Then dry-run the whole resolve
+#   with the same parsing the script uses:
+#     apt-get -s install $(sed -e 's/#.*//' -e 's/[[:space:]]//g' aptfile-ubuntu)
+#   The -s simulation needs no root and changes nothing; it should end in a
+#   "N newly installed" line with no "Unable to locate" and no E: lines.
+#
+# WHAT IS *NOT* HERE
+#   Anything that apt doesn't ship (or ships too stale to bother with) is
+#   installed by `setup-ubuntu.sh` directly — mise, starship, pnpm/corepack,
+#   zsh-fast-syntax-highlighting, and ngrok. See the last section of this file.
+#
+# TARGET: Ubuntu 24.04.x LTS (noble), x86_64, headless server. No GUI packages —
+# nothing here should pull X11, Wayland, or a desktop stack.
+
+
+# ---- Shell ----
+# zsh is the login shell. The two plugin packages are Ubuntu-packaged and get
+# sourced from /usr/share/zsh-*/ by `zshrc` (no git clone needed for these two).
+zsh
+zsh-autosuggestions
+zsh-syntax-highlighting
+
+
+# ---- Editor ----
+# vim-nox is the "everything but the GUI" build: +ruby +python3 +perl +lua, which
+# the vimrc/plugins want. It registers /usr/bin/vim via update-alternatives at
+# priority 40, beating vim.basic's 30, so it takes over `vim` automatically with
+# no manual `update-alternatives --set` step.
+vim-nox
+
+
+# ---- Multiplexers ----
+# Long-running remote sessions. tmux.conf and screenrc are both in this repo.
+tmux
+screen
+
+
+# ---- Version control ----
+# git-lfs still needs a one-time `git lfs install` per user (setup-ubuntu.sh does it).
+# NOTE: noble universe ships gh 2.45.0, which is ~2 years behind upstream (2.97.0).
+# It is fine for the things actually used here — auth, repo, pr, issue, run — but
+# newer subcommands and flags won't exist. If you need current gh, add GitHub's own
+# apt repo (cli.github.com); see the README.
+git
+git-lfs
+gh
+
+
+# ---- Core CLI ----
+# The everyday toolbelt: fetching, searching, inspecting, archiving.
+# NOTE on two renames: Debian/Ubuntu ship `bat` as the binary `batcat` (the name
+# `bat` collides with bacula-console-qt) and `fd-find` as `fdfind` (collides with
+# fdclone). setup-ubuntu.sh symlinks both to their real names in ~/.local/bin, so
+# `bat` and `fd` work as expected once that's on PATH.
+curl
+wget
+jq
+tree
+fzf
+ripgrep
+bat
+fd-find
+htop
+ncdu
+unzip
+zip
+less
+man-db
+locales
+ca-certificates
+gnupg
+openssh-client
+rsync
+bash-completion
+direnv
+
+
+# ---- Python tooling ----
+# Ubuntu 24.04's system python is PEP 668 "externally managed": `pip install` into
+# it is refused on purpose. Do not fight it with --break-system-packages. Use a
+# mise-managed python, a venv, or pipx (which makes its own venv per CLI tool).
+# python3-dev is here so that C extensions build against the system python when
+# something insists on it.
+python3-pip
+python3-venv
+python3-dev
+pipx
+
+
+# ---- Build toolchain ----
+# C/C++ compile + the autotools/cmake/ninja trio, for native gems, python wheels
+# with C extensions, and embedded work.
+# `pkgconf` is the real implementation in noble; `pkg-config` is just a compat
+# wrapper built from the same source version, so listing pkgconf is enough.
+# `gawk` because Ubuntu's default awk is mawk, which lacks GNU extensions that
+# ruby-build and various Makefiles assume.
+build-essential
+autoconf
+automake
+libtool
+pkgconf
+cmake
+ninja-build
+patch
+gawk
+bison
+ccache
+
+
+# ---- Ruby / Python build headers (mise source-build fallback) ----
+# READ THIS BEFORE TRIMMING: mise installs PRECOMPILED node/python/ruby by
+# default, so on a normal day none of these are touched. They are insurance for
+# the case where a requested version has no prebuilt artifact for this platform
+# and mise falls back to compiling from source — at which point a missing header
+# means a silently feature-crippled build (no readline in irb, no ssl in pip, no
+# sqlite3 module) rather than a clean error. Cheap to have, painful to lack.
+#
+# STALE-DOC WARNING: the ruby-build and pyenv wikis still tell Ubuntu users to
+# install libreadline6-dev, libncurses5-dev, libncursesw5-dev and libgdbm6. On
+# noble NONE of those four exist as real packages any more. They survive only as
+# virtual `Provides:` aliases on the modern names, so a hand-typed
+# `apt install libncurses5-dev` does still work — it silently resolves to
+# libncurses-dev (same for libncursesw5-dev; libreadline6-dev -> libreadline-dev;
+# libgdbm6 -> libgdbm6t64, the 64-bit-time_t ABI rename).
+# But a virtual name has NO candidate version of its own — `apt-cache policy`
+# prints "Candidate: (none)" — which is exactly what an availability filter keys
+# on, so putting the legacy spellings in THIS file would get them quietly dropped
+# by setup-ubuntu.sh and you'd build without readline/ncurses and never be told.
+# Always use the real names below. libgdbm6t64 arrives as a dependency of
+# libgdbm-dev anyway, so it never needs its own line.
+libssl-dev
+zlib1g-dev
+libyaml-dev
+libffi-dev
+libreadline-dev
+libncurses-dev
+libgdbm-dev
+libgdbm-compat-dev
+libdb-dev
+libbz2-dev
+libsqlite3-dev
+liblzma-dev
+uuid-dev
+libgmp-dev
+xz-utils
+
+
+# ---- Containers ----
+# noble-updates carries Docker Engine 29.x, so the universe packages are current
+# rather than stale — no need for Docker's own apt repo on this box.
+# `docker-buildx` must be listed explicitly: docker.io only Suggests it, so a
+# plain `apt install docker.io` leaves you without `docker buildx`.
+# `docker-compose-v2` is the Go plugin invoked as `docker compose`. Do NOT add
+# `docker-compose` — that is the deprecated Python v1 `docker-compose` binary.
+# setup-ubuntu.sh runs `usermod -aG docker $USER`; group membership only applies
+# to new logins, so log all the way out and back in (a new shell is not enough).
+docker.io
+docker-compose-v2
+docker-buildx
+
+
+# ============================================================================
+# OPTIONAL — all commented out. Uncomment a line and re-run setup-ubuntu.sh
+# (or `sudo apt install <pkg>`). Every name below was verified to resolve on
+# noble, so uncommenting is safe. Sizes are installed-size deltas.
+#
+# TO ENABLE ONE: delete only the LEADING "#". Any trailing "# note" on the line
+# can stay — the reader strips from the first `#` onward, so `entr  # rerun ...`
+# is read as just `entr`.
+# ============================================================================
+
+# ---- Python / Ruby build extras ----
+# Only needed for specific interpreter features. Sizes below were measured on
+# noble as the delta on top of the default list above (apt-get -s install).
+# tk-dev            # +21 MB but +30 pkgs — drags in the whole X11 header stack
+#                   # (libx11-dev, x11proto-dev, libxcb1-dev, libxft-dev, ...) on a
+#                   # headless box. ONLY needed for tkinter / IDLE. Skip unless you
+#                   # actually import tkinter.
+# llvm              # +513 MB (llvm-18-dev alone is 329 MB) — NOT needed to build
+#                   # CPython with gcc; only for clang/JIT work.
+# libxml2-dev       # for nokogiri/lxml built from source (both usually ship binaries)
+# libxmlsec1-dev    # for the xmlsec / SAML gems
+# rustc             # some newer gems and python wheels have Rust extensions
+# cargo             # ditto
+
+# ---- Linting / text ----
+# shellcheck
+# yamllint
+# aspell
+# aspell-en
+# silversearcher-ag   # `ag`; ripgrep above already covers this, keep for muscle memory
+
+# ---- Media / documents (heavy) ----
+# All of these pull large codec/font/library trees. Only install on a box that
+# actually processes media or PDFs.
+# imagemagick
+# ffmpeg
+# ghostscript
+# poppler-utils
+# tesseract-ocr
+
+# ---- Services ----
+# These install systemd units that start on boot — check `systemctl status`
+# after installing and disable what you don't want listening.
+# redis-server
+# mosquitto
+# mosquitto-clients
+# sqlite3             # the CLI; libsqlite3-dev above is the library
+
+# ---- Embedded / C++ (mirrors the Brewfile's embedded toolchain) ----
+# clang-format
+# cppcheck
+# lcov
+# gcovr
+# gperf
+# dfu-util
+# device-tree-compiler   # `dtc` in the Brewfile
+# minicom
+# qemu-system            # large; the full system-emulation set
+# qemu-utils             # small; just qemu-img and friends
+
+# ---- Server ops / diagnostics ----
+# smartmontools
+# sysstat
+# lsof
+# strace
+# socat
+# netcat-openbsd
+# dnsutils            # dig, nslookup
+# moreutils           # sponge, ts, vipe, chronic
+# entr                # rerun a command when files change
+# plocate             # faster mlocate; adds a daily updatedb timer
+# universal-ctags
+# p7zip-full
+# libarchive-tools    # bsdtar
+
+# ---- Modern CLI (nice-to-have replacements) ----
+# btop
+# tig
+# git-delta           # binary is `delta`
+# zoxide
+# eza                 # ls replacement, the maintained exa fork
+# hyperfine
+# httpie
+# tldr
+# pv
+
+# ---- JVM / language / misc ----
+# maven
+# openjdk-17-jdk
+# emacs-nox           # terminal-only emacs, no X deps
+# libpq-dev           # headers for the pg gem / psycopg2 source builds
+# libcurl4-openssl-dev
+
+
+# ============================================================================
+# NOT AVAILABLE VIA APT — handled separately in setup-ubuntu.sh
+# ============================================================================
+# Do not try to add these here; apt either has no package or has one too old to
+# be worth it. setup-ubuntu.sh installs each one:
+#
+#   mise      — official signed apt repo (mise.jdx.dev), added by the script with
+#               its own keyring. Manages ruby/python/node; replaces rbenv/pyenv/fnm.
+#   starship  — upstream install.sh into ~/.local/bin. Config is starship.toml.
+#   pnpm      — via corepack, which ships with node, so mise-node must be
+#               installed FIRST. Do not `apt install npm`; see the npm alias in zshrc.
+#   zsh-fast-syntax-highlighting
+#             — not packaged; git clone into ~/.zsh. Note this is a *different*
+#               plugin from the zsh-syntax-highlighting deb listed up top.
+#   ngrok     — official apt repo (ngrok.com), added by the script.
+#
+# Also, from the Brewfile but deliberately NOT here: coreutils, gnu-sed, gawk-as-
+# a-replacement. On the Mac those exist to replace BSD userland with GNU. Linux
+# is already GNU — /usr/bin/sed, ls, date etc. are the GNU versions, so there is
+# nothing to install and no `g`-prefixed binaries to alias around.
+# (`gawk` IS listed above, but only because Ubuntu's default awk is mawk.)

--- a/bin/newrc
+++ b/bin/newrc
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAME="${1:-}"; REPO="${2:-}"
+ROOT="$HOME/workspaces/claude-rc-projects"
+
+[[ -n "$NAME" ]] || { echo "usage: newrc <name> [git-url]" >&2; exit 1; }
+[[ "$NAME" != */* ]] || { echo "name cannot contain /" >&2; exit 1; }
+
+DIR="$ROOT/$NAME"
+if [[ -n "$REPO" ]]; then
+  [[ ! -e "$DIR" ]] || { echo "$DIR already exists" >&2; exit 1; }
+  git clone "$REPO" "$DIR"
+else
+  mkdir -p "$DIR"
+fi
+
+python3 - "$DIR" <<'PY'
+import json, os, sys, tempfile
+p = os.path.expanduser("~/.claude.json")
+try:
+    cfg = json.load(open(p))
+except FileNotFoundError:
+    cfg = {}
+cfg.setdefault("projects", {}).setdefault(sys.argv[1], {})["hasTrustDialogAccepted"] = True
+fd, tmp = tempfile.mkstemp(dir=os.path.dirname(p))
+with os.fdopen(fd, "w") as f:
+    json.dump(cfg, f, indent=2)
+os.chmod(tmp, 0o600); os.replace(tmp, p)
+PY
+
+systemctl --user enable --now "claude-rc@$NAME"
+sleep 3
+systemctl --user is-active "claude-rc@$NAME"

--- a/claude/settings-ubuntu.json
+++ b/claude/settings-ubuntu.json
@@ -1,0 +1,10 @@
+{
+  "statusLine": {
+    "type": "command",
+    "command": "bash ~/.claude/statusline-command.sh"
+  },
+  "tui": "fullscreen",
+  "theme": "dark",
+  "model": "sonnet",
+  "autoUpdatesChannel": "stable"
+}

--- a/gitconfig-ubuntu
+++ b/gitconfig-ubuntu
@@ -1,0 +1,129 @@
+# Ubuntu variant of the sibling `gitconfig`.
+#
+# The ONLY difference from `gitconfig` is that the `hooksPath = ~/.git-hooks` line has
+# been removed from the [core] section: the AI-generated `prepare-commit-msg` hook calls
+# the OpenAI API on every `git commit`, and that is explicitly opted out of on this server.
+#
+# To enable it later: add `hooksPath = ~/.git-hooks` back under [core], and symlink
+# `git_hooks/prepare-commit-msg` into `~/.git-hooks/`.
+
+# -- START TIDBITS --
+############################################################
+# SHARED GIT CONFIGURATION
+############################################################
+# This is a shared git-config file. It should be inserted at the top of your
+# ~/.gitconfig file which allows you to override settings by placing them farther
+# down in the file.
+#
+##############################
+# POTENTIAL CONFLICTS WITH GIT
+##############################
+# git-config commands like add/remove are not smart enough to add/remove settings
+# from the proper place in your ~/gitconfig file when using shared configs. You may 
+# need to add/remove them manually. If you store your ~/.gitconfig file in a git repository
+# itself then it will be extremely easy to see if unexpected changes occurred. For more
+# information on how-to do that contact your local git ninja.
+
+[alias]
+  
+  # +head+ shows the latest commit for the current branch
+  head = log -n1
+  
+  # +del+ will have run "git rm" on any files you deleted so git knows to delete them to
+  del = !"git status | grep deleted | cut -d' ' -f 5 | xargs git rm 2> /dev/null"
+
+  # +cbranch+ returns the current branch you are on
+  cbranch = !"git branch | grep '*' | cut -f2 -d' '"
+  
+  # +rbranch+ returns the remote branch for the current branch you are on assuming it
+  # is named the same
+  rbranch = !"git branch -r | grep -E \"/`git cbranch`$\" | grep -v -e \"->\""
+  
+  # +review+ shows changes in the remote branch that your current local branch does not have
+  review = !"git log `git cbranch`..`git rbranch`"
+  
+  # +rreview+ shows changes in your local branch that its remote branch does not have
+  rreview = !"git log `git rbranch`..`git cbranch`"
+  
+  # +rollback+ performs a "git reset --soft HEAD~n" where n is a parameter you
+  # pass in, ie: git rollback 1 is the same as git reset --soft HEAD~1
+  rollback = !"function mhsrc_gitconfig_rollback(){ num=$1 ;git reset --soft HEAD~$num ; echo Rolled back softly $num commits ;} ; mhsrc_gitconfig_rollback "
+  
+  # +unmerged+ - see http://mutuallyhuman.com/blog/2009/07/02/finding-unmerged-commits-with-git-unmerged
+  unmerged = !"ruby ~/.tidbits/lib/git-unmerged.rb"
+  
+  # +anim+ - lists branches merged into acceptance that are not in master. (anim == acceptance not in master)
+  anim = !"echo 'Branches merged into acceptance that are not in master:' && git log master..acceptance | grep -i 'Merge branch'"
+  
+  # +pushr+ - pushes the current branch to the remote origin
+  pushr = !"git push --set-upstream origin `git cbranch`"
+
+  # +pre+ - shortcut for pull --rebase
+  pre = pull --rebase
+  
+############################################################
+# END SHARED GIT CONFIGURATION
+############################################################
+
+# -- END TIDBITS --
+
+[user]
+	name = softwaregravy
+	email = 426690+softwaregravy@users.noreply.github.com
+[alias]
+  st = status
+  ci = commit
+  br = branch
+  co = checkout
+  df = diff
+  dc = diff --cached
+  lg = log -p
+  lol = log --graph --decorate --pretty=oneline --abbrev-commit
+  lola = log --graph --decorate --pretty=oneline --abbrev-commit --all
+  ls = ls-files
+
+  # Show files ignored by git:
+  ign = ls-files -o -i --exclude-standard
+	d = difftool
+	ignore = "!gi() { curl -L -s https://www.gitignore.io/api/$@ ;}; gi"
+
+[core]
+	quotepath = false
+	autocrlf = input
+	whitespace = cr-at-eol
+	pager = less -r
+
+[diff]
+  tool = less -r
+  # tool = vimdiff
+  # external = ~/.git_diff_wrapper
+[pager]
+  diff = less -r
+[push]
+	default = simple
+[heroku]
+	account = work
+[init]
+	templatedir = ~/.git_template
+	defaultBranch = main
+[help]
+	autocorrect = 1
+[difftool]
+	prompt = false
+[merge]
+	tool = vimdiff
+[filter "lfs"]
+	required = true
+	clean = git-lfs clean -- %f
+	smudge = git-lfs smudge -- %f
+	process = git-lfs filter-process
+[color]
+  diff = auto
+  status = auto
+  branch = auto
+  interactive = auto
+  pager = true
+[pull]
+	rebase = false
+[fetch]
+	prune = true

--- a/keys/bland
+++ b/keys/bland
@@ -1,1 +1,0 @@
-export BLAND_API_KEY="your key here"

--- a/setup-ubuntu.sh
+++ b/setup-ubuntu.sh
@@ -1,0 +1,952 @@
+#!/usr/bin/env bash
+#
+# setup-ubuntu.sh — Ubuntu counterpart to setup.sh (which is macOS/Homebrew only).
+#
+# Bootstraps a headless Ubuntu server (tested on 24.04 "noble", x86_64) with the
+# same terminal workflow as the Mac: zsh + starship + vim + tmux + mise + direnv.
+# Packages come from apt (see aptfile-ubuntu) instead of Homebrew.
+#
+# Config files: anything already portable is symlinked straight from this repo;
+# anything that needed changes has a "-ubuntu" sibling (zshrc-ubuntu, vimrc-ubuntu,
+# tmux.conf-ubuntu, gitconfig-ubuntu, claude/settings-ubuntu.json). The macOS
+# originals are never touched.
+#
+# Run it from a detached tmux/screen session, NOT from an agent's shell tool:
+# it takes ~10 minutes and a mid-dpkg kill leaves apt half-configured.
+#
+#   tmux new -s setup
+#   ./setup-ubuntu.sh
+#
+# It changes your login shell to zsh, adds you to the docker group, and replaces
+# files in $HOME. Everything replaced is moved to ~/.dotfiles-backup/<timestamp>/.
+
+set -euo pipefail
+
+# -----------------------------------------------------------------------------
+# | Options                                                                    |
+# -----------------------------------------------------------------------------
+
+ASSUME_YES=0
+SKIP_APT=0
+DO_CHSH=1
+
+usage() {
+  cat <<'USAGE'
+Usage: setup-ubuntu.sh [OPTIONS]
+
+  -h, --help      Show this help and exit.
+  -y, --yes       Never prompt. Back up and replace anything in the way.
+                  Required for `curl | bash` and any run without a terminal.
+      --skip-apt  Skip package installation. Turns a "just fix my symlinks"
+                  re-run into a few seconds instead of a few minutes.
+      --no-chsh   Do everything except change the login shell to zsh.
+
+Env:
+  SYSTEM_FILES_DIR  Override the repo location. Defaults to the directory this
+                    script lives in, else ~/workspaces/system_files.
+
+Run this from a detached tmux/screen session, not from an agent's shell tool.
+It changes your login shell, adds you to the docker group, and replaces files
+in $HOME (everything replaced is moved to ~/.dotfiles-backup/<timestamp>/).
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -h|--help)   usage; exit 0 ;;
+    -y|--yes)    ASSUME_YES=1 ;;
+    --skip-apt)  SKIP_APT=1 ;;
+    --no-chsh)   DO_CHSH=0 ;;
+    *) echo "Unknown option: $1" >&2; usage >&2; exit 2 ;;
+  esac
+  shift
+done
+
+# -----------------------------------------------------------------------------
+# | Logging, warnings, teardown                                                |
+# -----------------------------------------------------------------------------
+
+WARNINGS=()
+BACKED_UP=()
+SUDO_KEEPALIVE_PID=""
+START_TS=$(date +%s)
+
+# Detect a terminal BEFORE stdout gets redirected into tee.
+HAS_TTY=0
+if [[ -t 1 ]] && [[ -r /dev/tty ]]; then HAS_TTY=1; fi
+
+if (( HAS_TTY )); then
+  C_RED=$'\033[31m'; C_YEL=$'\033[33m'; C_GRN=$'\033[32m'; C_OFF=$'\033[0m'
+else
+  C_RED=""; C_YEL=""; C_GRN=""; C_OFF=""
+fi
+
+say()  { printf '%s\n' "$*"; }
+step() { printf '\n%s==> %s%s\n' "$C_GRN" "$*" "$C_OFF"; }
+warn() { WARNINGS+=("$*"); printf '%s[WARN]%s %s\n' "$C_YEL" "$C_OFF" "$*" >&2; }
+die()  { printf '%s[FATAL]%s %s\n' "$C_RED" "$C_OFF" "$*" >&2; exit 1; }
+
+# Run a phase without letting it abort the script.
+#
+# Be precise about what this does: invoking a function in a condition context
+# suspends `set -e` for its whole body. So a failure PART WAY THROUGH a phase is
+# neither caught here nor fatal — the phase just keeps going, and only its final
+# command's status decides whether the warning below fires. That is why every
+# risky command inside a phase carries its own `|| warn ...` and every phase ends
+# in `return 0`; this wrapper is only the backstop.
+#
+# `die` still works from inside a phase: `exit` is not subject to the exemption,
+# so a genuinely fatal problem stops the run and the EXIT trap still prints the
+# summary.
+soft() {
+  local label=$1; shift
+  if ! "$@"; then
+    warn "$label failed — continuing. Re-run setup-ubuntu.sh to retry."
+  fi
+  return 0
+}
+
+cleanup() {
+  local rc=$?
+  if [[ -n "$SUDO_KEEPALIVE_PID" ]] && kill -0 "$SUDO_KEEPALIVE_PID" 2>/dev/null; then
+    kill "$SUDO_KEEPALIVE_PID" 2>/dev/null || :
+    wait "$SUDO_KEEPALIVE_PID" 2>/dev/null || :
+  fi
+  print_summary "$rc"
+  # Give the tee in the output pipeline a moment to flush.
+  sleep 0.3
+  return $rc
+}
+
+# -----------------------------------------------------------------------------
+# | P0 — Preflight                                                             |
+# -----------------------------------------------------------------------------
+
+[[ "$(uname -s)" == "Linux" ]] || die "This script is for Linux. On macOS run ./setup.sh instead."
+
+if [[ ${EUID:-$(id -u)} -eq 0 ]]; then
+  die "Do not run this as root (or with sudo). It creates files in \$HOME and
+       would leave them root-owned. Run it as your normal user; it will prompt
+       for sudo once, when it needs it."
+fi
+
+if [[ -r /etc/os-release ]]; then
+  # shellcheck disable=SC1091
+  . /etc/os-release
+  [[ "${ID:-}" == "ubuntu" || "${ID_LIKE:-}" == *debian* ]] \
+    || warn "Not Ubuntu/Debian (ID=${ID:-?}) — apt package names may not match."
+fi
+
+# Resolve the repo. Prefer the directory this script lives in, so running it
+# from a checkout Just Works regardless of where that checkout is.
+DEFAULT_REPO="$HOME/workspaces/system_files"
+if [[ -n "${SYSTEM_FILES_DIR:-}" ]]; then
+  REPO_DIR="$SYSTEM_FILES_DIR"
+elif [[ -n "${BASH_SOURCE[0]:-}" ]] && [[ -f "$(dirname "${BASH_SOURCE[0]}")/setup-ubuntu.sh" ]]; then
+  REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+else
+  REPO_DIR="$DEFAULT_REPO"
+fi
+
+CLONED_REPO=0
+if [[ ! -d "$REPO_DIR" ]]; then
+  step "Cloning system files repository to $REPO_DIR"
+  mkdir -p "$(dirname "$REPO_DIR")"
+  git clone https://github.com/softwaregravy/system_files.git "$REPO_DIR" \
+    || die "could not clone the repo to $REPO_DIR"
+  CLONED_REPO=1
+fi
+[[ -f "$REPO_DIR/setup-ubuntu.sh" ]] || die "$REPO_DIR does not look like the system_files repo"
+
+# Deliberately NOT pulling when running from an existing checkout: bash reads a
+# script by byte offset as it executes, and rewriting it mid-run is asking for
+# trouble. Pull it yourself before running.
+if (( CLONED_REPO == 0 )); then
+  say "Using repo at $REPO_DIR (run 'git pull' yourself if you want it updated first)"
+fi
+
+RUN_ID="$(date +%Y%m%dT%H%M%S)"
+BACKUP_DIR="$HOME/.dotfiles-backup/$RUN_ID"
+LOG_FILE="$BACKUP_DIR/setup.log"
+mkdir -p "$BACKUP_DIR"
+
+# Everything from here on is teed to the log. A 10 minute run scrolls its
+# warnings off screen otherwise.
+exec > >(tee -a "$LOG_FILE") 2>&1
+
+say "system_files Ubuntu setup"
+say "  repo:    $REPO_DIR"
+say "  backups: $BACKUP_DIR"
+say "  log:     $LOG_FILE"
+say "  user:    $USER ($(id -u))  host: $(hostname)"
+
+# ~/.local/bin holds starship, bat, fd, newrc and (already) claude. It must
+# exist and be on PATH *in this process* — ~/.profile only adds it at login,
+# which already happened.
+mkdir -p "$HOME/.local/bin"
+export PATH="$HOME/.local/bin:$PATH"
+
+# mise compiling a runtime from source wants several GB.
+avail_kb=$(df -Pk "$HOME" | awk 'NR==2 {print $4}')
+if [[ -n "${avail_kb:-}" ]] && (( avail_kb < 8000000 )); then
+  warn "only $((avail_kb / 1024)) MB free in $HOME — apt (~900MB) plus mise runtimes may not fit"
+fi
+
+if (( HAS_TTY == 0 )) && (( ASSUME_YES == 0 )); then
+  warn "No terminal detected and --yes not given: anything already in the way will be SKIPPED, not replaced."
+fi
+
+# -----------------------------------------------------------------------------
+# | Helpers                                                                    |
+# -----------------------------------------------------------------------------
+
+confirm() {
+  local prompt=$1 reply="n"
+  (( ASSUME_YES )) && return 0
+  (( HAS_TTY )) || return 1
+  printf '%s (y/n) ' "$prompt" > /dev/tty
+  read -r reply < /dev/tty || reply="n"
+  [[ "$reply" == [yY] ]]
+}
+
+# Move a path into this run's backup directory, preserving its location under
+# $HOME. Unlike the Mac script's "<target>.backup" this can't clobber a previous
+# backup, can't leave an executable on $PATH, and can't drop a stray file into a
+# systemd unit directory.
+backup_path() {
+  local target=$1 rel dest
+  rel="${target#"$HOME"/}"; rel="${rel#/}"
+  dest="$BACKUP_DIR/$rel"
+  mkdir -p "$(dirname "$dest")"
+  mv "$target" "$dest"
+  say "  backed up $target -> $dest"
+  BACKED_UP+=("$target")
+}
+
+# Files we know are in the way and that the user has already decided to adopt
+# from the repo. Replacing these silently (after backing them up) beats asking.
+AUTO_REPLACE=(
+  "$HOME/.claude/settings.json"
+  "$HOME/.local/bin/newrc"
+  "$HOME/.config/systemd/user/claude-rc@.service"
+)
+
+is_auto_replace() {
+  local t=$1 x
+  for x in "${AUTO_REPLACE[@]}"; do [[ "$x" == "$t" ]] && return 0; done
+  return 1
+}
+
+create_symlink() {
+  local source=$1 target=$2 current
+
+  if [[ ! -e "$source" ]]; then
+    warn "missing source — not linking: $source -> $target"
+    return 0
+  fi
+  source="$(realpath "$source")"
+  mkdir -p "$(dirname "$target")"
+
+  if [[ -L "$target" ]]; then
+    current="$(readlink "$target")"
+    if [[ "$current" == "$source" ]]; then
+      say "  ok        $target"
+      return 0
+    fi
+    say "  $target currently points to $current"
+    if confirm "  Repoint it to $source?"; then
+      ln -sfn "$source" "$target"
+      say "  relinked  $target -> $source"
+    else
+      warn "left existing symlink alone: $target -> $current"
+    fi
+    return 0
+  fi
+
+  if [[ -e "$target" ]]; then
+    if is_auto_replace "$target" || confirm "  $target exists and is not a symlink. Back it up and replace?"; then
+      backup_path "$target"
+      ln -sfn "$source" "$target"
+      say "  replaced  $target -> $source"
+    else
+      warn "SKIPPED (exists, not a symlink): $target"
+    fi
+    return 0
+  fi
+
+  ln -sfn "$source" "$target"
+  say "  linked    $target -> $source"
+}
+
+# Symlink one *name* inside ~/.local/bin. Never globs — ~/.local/bin also holds
+# the `claude` symlink, which must not be disturbed.
+link_bin() {
+  # Split across two statements on purpose: bash expands every word of a `local`
+  # command before performing any of its assignments, so referencing $name in
+  # the same statement that declares it reads the (unset) outer scope and trips
+  # `set -u`.
+  local source=$1 name=$2
+  local target="$HOME/.local/bin/$name"
+  [[ -e "$source" ]] || { warn "not found, skipping shim: $source"; return 0; }
+  if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
+    say "  ok        $target"
+    return 0
+  fi
+  [[ -e "$target" && ! -L "$target" ]] && backup_path "$target"
+  ln -sfn "$source" "$target"
+  say "  shim      $target -> $source"
+}
+
+require_sudo() {
+  sudo -n true 2>/dev/null && return 0
+  say "Re-authenticating for sudo..."
+  sudo -v
+}
+
+# -----------------------------------------------------------------------------
+# | P1 — sudo                                                                  |
+# -----------------------------------------------------------------------------
+
+phase_sudo() {
+  step "sudo"
+  say "This script needs sudo for apt, the docker group, and chsh."
+  say "You should be prompted once, now."
+  sudo -v || die "sudo is required"
+
+  # Keep the timestamp warm for the length of the run. `sudo -n true` is the
+  # loop *condition*, so `set -e` can't kill the loop silently, and the loop
+  # ends on its own the moment credentials can't be refreshed. The PID is
+  # reaped in the EXIT trap rather than by polling the parent's PID (which
+  # can outlive the script and, on PID reuse, never terminate).
+  sudo -n true 2>/dev/null \
+    || warn "sudo does not appear to cache credentials here; expect repeated prompts"
+  ( while sudo -n true 2>/dev/null; do sleep 45; done ) &
+  SUDO_KEEPALIVE_PID=$!
+  disown "$SUDO_KEEPALIVE_PID" 2>/dev/null || :
+}
+
+# -----------------------------------------------------------------------------
+# | P2 — apt                                                                   |
+# -----------------------------------------------------------------------------
+
+APTFILE="$REPO_DIR/aptfile-ubuntu"
+
+add_apt_repos() {
+  require_sudo
+  sudo install -dm 755 /etc/apt/keyrings
+
+  # mise — not in the Ubuntu archive at all. Official signed repo.
+  # `| sudo tee` (never `>>`) so re-running truncates instead of appending.
+  if [[ ! -f /etc/apt/keyrings/mise-archive-keyring.gpg ]]; then
+    say "  adding the mise apt repo"
+    curl -fsSL https://mise.jdx.dev/gpg-key.pub \
+      | gpg --dearmor \
+      | sudo tee /etc/apt/keyrings/mise-archive-keyring.gpg >/dev/null \
+      || warn "could not add the mise signing key"
+  fi
+  echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=amd64] https://mise.jdx.dev/deb stable main" \
+    | sudo tee /etc/apt/sources.list.d/mise.list >/dev/null
+
+  # ngrok — also absent from the archive. The "bookworm" suite name is correct
+  # on Ubuntu too: it's a single-suite repo of static binaries.
+  if [[ ! -f /etc/apt/keyrings/ngrok.gpg ]]; then
+    say "  adding the ngrok apt repo"
+    curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc \
+      | gpg --dearmor \
+      | sudo tee /etc/apt/keyrings/ngrok.gpg >/dev/null \
+      || warn "could not add the ngrok signing key"
+  fi
+  echo "deb [signed-by=/etc/apt/keyrings/ngrok.gpg] https://ngrok-agent.s3.amazonaws.com bookworm main" \
+    | sudo tee /etc/apt/sources.list.d/ngrok.list >/dev/null
+}
+
+phase_apt() {
+  step "apt packages"
+  require_sudo
+
+  # curl/gnupg are needed to add the signed repos below.
+  sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l NEEDRESTART_SUSPEND=1 \
+    apt-get install -y -o DPkg::Lock::Timeout=600 curl ca-certificates gnupg \
+    || warn "could not install curl/ca-certificates/gnupg"
+
+  add_apt_repos || warn "third-party apt repos could not be added"
+
+  say "  apt-get update"
+  # A single unreachable repo makes this non-zero while leaving the rest of the
+  # cache perfectly usable, so don't treat it as fatal — the availability filter
+  # below is what actually decides whether we can proceed.
+  sudo apt-get update -o DPkg::Lock::Timeout=600 || warn "apt-get update reported errors"
+
+  [[ -f "$APTFILE" ]] || { warn "no $APTFILE — skipping package installation"; return 0; }
+
+  local pkgs=() avail=() missing=() p
+  mapfile -t pkgs < <(sed -e 's/#.*//' -e 's/[[:space:]]//g' "$APTFILE" | grep -v '^$' || true)
+  (( ${#pkgs[@]} )) || { warn "$APTFILE contained no package names"; return 0; }
+
+  # These two come from the third-party repos added by add_apt_repos, not from
+  # Ubuntu's archive, so they are deliberately NOT listed in aptfile-ubuntu
+  # (that file documents itself as covering only what plain Ubuntu ships).
+  # They still have to be installed, though — adding a repo and then never
+  # pulling from it is how mise silently went missing.
+  pkgs+=(mise ngrok)
+
+  # NOTE: do NOT write this as `apt-cache policy "$p" | grep -q ...`. grep -q
+  # exits on first match, apt-cache takes SIGPIPE, and `pipefail` surfaces 141 —
+  # every single time. That would silently mark every package unavailable.
+  for p in "${pkgs[@]}"; do
+    if apt-cache show "$p" >/dev/null 2>&1; then avail+=("$p"); else missing+=("$p"); fi
+  done
+
+  if (( ${#missing[@]} )); then
+    warn "not available in apt, skipping: ${missing[*]}"
+  fi
+  (( ${#avail[@]} )) || { warn "no installable packages found"; return 0; }
+
+  say "  installing ${#avail[@]} packages (this is the slow part)"
+  # NEEDRESTART_MODE=l / NEEDRESTART_SUSPEND=1 matter a lot here: Ubuntu's apt
+  # hook defaults to automatically restarting affected services, and that list
+  # can include user@$UID.service — which would kill any running tmux server,
+  # including `claude remote-control` sessions and possibly this script.
+  sudo env DEBIAN_FRONTEND=noninteractive NEEDRESTART_MODE=l NEEDRESTART_SUSPEND=1 \
+    apt-get install -y \
+      -o DPkg::Lock::Timeout=600 \
+      -o Dpkg::Options::=--force-confold \
+      "${avail[@]}" \
+    || warn "apt-get install reported errors — check the log above"
+
+  # Only these three make the rest of the script meaningful.
+  local hard
+  for hard in zsh git curl; do
+    command -v "$hard" >/dev/null 2>&1 || die "$hard is still missing after apt — cannot continue"
+  done
+}
+
+# -----------------------------------------------------------------------------
+# | P3 — ~/.local/bin shims                                                    |
+# -----------------------------------------------------------------------------
+
+phase_shims() {
+  step "command shims"
+  # Debian renames both of these because of filename clashes with unrelated
+  # packages (bacula-console-qt ships /usr/bin/bat, fdclone ships /usr/bin/fd).
+  [[ -x /usr/bin/batcat ]] && link_bin /usr/bin/batcat bat
+  [[ -x /usr/bin/fdfind ]] && link_bin /usr/bin/fdfind fd
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P4 — starship, fast-syntax-highlighting                                    |
+# -----------------------------------------------------------------------------
+
+phase_starship() {
+  step "starship"
+  if command -v starship >/dev/null 2>&1; then
+    say "  already installed: $(command -v starship)"
+    return 0
+  fi
+  # Not packaged for Ubuntu. Installed into ~/.local/bin so it needs no sudo.
+  curl -fsSL https://starship.rs/install.sh \
+    | sh -s -- --yes --bin-dir "$HOME/.local/bin" \
+    || warn "starship install failed (network?); the prompt will fall back to plain zsh"
+  return 0
+}
+
+phase_fsh() {
+  step "zsh fast-syntax-highlighting"
+  local dir="$HOME/.zsh/fast-syntax-highlighting"
+  if [[ -d "$dir/.git" ]]; then
+    git -C "$dir" pull --ff-only || warn "could not update fast-syntax-highlighting"
+  else
+    mkdir -p "$HOME/.zsh"
+    git clone --depth 1 https://github.com/zdharma-continuum/fast-syntax-highlighting.git "$dir" \
+      || { warn "fast-syntax-highlighting clone failed; zshrc falls back to apt's zsh-syntax-highlighting"; return 0; }
+  fi
+  # umask here is 0002, so a fresh clone is group-writable and compaudit will
+  # complain about it on every login.
+  chmod -R go-w "$HOME/.zsh" || :
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P5/P6 — language runtimes                                                  |
+# -----------------------------------------------------------------------------
+
+phase_mise() {
+  step "language runtimes (mise)"
+  if ! command -v mise >/dev/null 2>&1; then
+    warn "mise not installed — skipping runtimes. Install it later, then re-run."
+    return 0
+  fi
+
+  # Honour .ruby-version / .node-version / .python-version. Modern mise ignores
+  # these by default, so without this `cd` into a project would not switch.
+  mise settings idiomatic_version_file_enable_tools=ruby,node,python \
+    || warn "could not set mise idiomatic_version_file_enable_tools"
+
+  # Deliberately three separate invocations: mise installs precompiled builds
+  # where it can, but if one falls back to compiling from source and fails, the
+  # others should still land. node first — corepack depends on it.
+  mise use --global node@lts   || warn "mise: node@lts failed (retry: mise use -g node@lts)"
+  mise use --global python@latest || warn "mise: python@latest failed (retry: mise use -g python@latest)"
+  mise use --global ruby@latest   || warn "mise: ruby@latest failed (retry: mise use -g ruby@latest)"
+  hash -r || :
+  return 0
+}
+
+phase_pnpm() {
+  step "pnpm"
+  if command -v pnpm >/dev/null 2>&1; then
+    say "  already installed: $(command -v pnpm)"
+    return 0
+  fi
+  command -v mise >/dev/null 2>&1 || { warn "no mise — skipping pnpm"; return 0; }
+
+  # mise only puts node on PATH via `mise activate`, which is interactive-only,
+  # so reach it explicitly. --install-directory matters: corepack's default
+  # target lives inside the mise node version directory and is orphaned on the
+  # next node upgrade.
+  if mise exec node@lts -- corepack enable --install-directory "$HOME/.local/bin" 2>/dev/null; then
+    say "  enabled via corepack"
+  elif mise use --global pnpm@latest; then
+    say "  installed via mise"
+  else
+    warn "could not install pnpm (try: mise use -g pnpm@latest)"
+  fi
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P7 — key templates                                                         |
+# -----------------------------------------------------------------------------
+
+phase_keys() {
+  step "API key templates"
+  local keys_dir="$HOME/.keys" template filename target
+  mkdir -p "$keys_dir"
+  chmod 700 "$keys_dir"
+  [[ -d "$REPO_DIR/keys" ]] || { warn "no keys/ directory in the repo"; return 0; }
+  for template in "$REPO_DIR"/keys/*; do
+    [[ -f "$template" ]] || continue
+    filename="$(basename "$template")"
+    target="$keys_dir/$filename"
+    # Never overwrite: these hold real secrets once filled in.
+    if [[ ! -f "$target" ]]; then
+      cp "$template" "$target" || { warn "could not create $target"; continue; }
+      chmod 600 "$target" || warn "could not chmod 600 $target"
+      say "  created template $target"
+    else
+      say "  ok        $target"
+    fi
+  done
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P8 — symlinks                                                              |
+# -----------------------------------------------------------------------------
+
+phase_links() {
+  step "symlinks"
+  # Left of the colon is relative to the repo. Files with a "-ubuntu" suffix
+  # needed real changes; everything else is portable as-is and is shared with
+  # the Mac setup.
+  local links=(
+    # ported
+    "zshrc-ubuntu:$HOME/.zshrc"
+    "vimrc-ubuntu:$HOME/.vimrc"
+    "tmux.conf-ubuntu:$HOME/.tmux.conf"
+    "gitconfig-ubuntu:$HOME/.gitconfig"
+    "claude/settings-ubuntu.json:$HOME/.claude/settings.json"
+    # shared, unchanged
+    "setup-ubuntu.sh:$HOME/setup-ubuntu.sh"
+    "screenrc:$HOME/.screenrc"
+    "inputrc:$HOME/.inputrc"
+    "irbrc:$HOME/.irbrc"
+    "gemrc:$HOME/.gemrc"
+    "npmrc:$HOME/.npmrc"
+    "starship.toml:$HOME/.config/starship.toml"
+    "CLAUDE.user.md:$HOME/.claude/CLAUDE.md"
+    "claude/statusline-command.sh:$HOME/.claude/statusline-command.sh"
+    "ir_black.vim:$HOME/.vim/colors/ir_black.vim"
+    "vim/after/syntax/sh.vim:$HOME/.vim/after/syntax/sh.vim"
+    # Linux-only. ngrok's config lives here, not in ~/Library/Application Support.
+    "ngrok.yml:$HOME/.config/ngrok/ngrok.yml"
+    "bin/newrc:$HOME/.local/bin/newrc"
+    "systemd/claude-rc@.service:$HOME/.config/systemd/user/claude-rc@.service"
+  )
+  local link source target
+  for link in "${links[@]}"; do
+    source="$REPO_DIR/${link%%:*}"
+    target="${link#*:}"
+    create_symlink "$source" "$target"
+  done
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P9 — vim plugins                                                           |
+# -----------------------------------------------------------------------------
+
+VIM_PACKAGES=(
+"https://github.com/preservim/nerdtree.git"
+"https://github.com/preservim/nerdcommenter.git"
+"https://github.com/vim-ruby/vim-ruby.git"
+"https://github.com/tpope/vim-rails.git"
+"https://github.com/tpope/vim-markdown.git"
+"https://github.com/pangloss/vim-javascript.git"
+"https://github.com/leafgarland/typescript-vim.git"
+"https://github.com/MaxMEllon/vim-jsx-pretty.git"
+"https://github.com/vim-scripts/AutoComplPop.git"
+"https://github.com/chrisbra/vim-zsh.git"
+# Linux-only: Vim 9.1 in Ubuntu has no native OSC 52 and never will (LTS does
+# not rebase vim), so copying to the Mac clipboard over SSH needs this plugin.
+"https://github.com/ojroques/vim-oscyank.git"
+# Add more packages here
+)
+
+phase_vim() {
+  step "vim plugins"
+  mkdir -p "$HOME/.vim/pack/vendor/start"
+  local repo_url package_name package_dir d
+  for repo_url in "${VIM_PACKAGES[@]}"; do
+    package_name="$(basename "$repo_url" .git)"
+    package_dir="$HOME/.vim/pack/vendor/start/$package_name"
+    if [[ -d "$package_dir/.git" ]]; then
+      say "  updating $package_name"
+      git -C "$package_dir" pull --ff-only >/dev/null 2>&1 || warn "could not update vim plugin $package_name"
+    else
+      say "  installing $package_name"
+      git clone --depth 1 "$repo_url" "$package_dir" >/dev/null 2>&1 \
+        || warn "could not clone vim plugin $package_name"
+    fi
+  done
+
+  say "  generating helptags"
+  # `vim -u NONE -c 'helptags ALL'` (what the Mac script does) is a no-op: -u NONE
+  # skips plugin loading, so pack/*/start/* never makes it onto runtimepath and
+  # nothing gets tagged. Tag each doc directory explicitly instead. </dev/null so
+  # vim can never start reading the rest of this script as keystrokes.
+  for d in "$HOME"/.vim/pack/vendor/start/*/doc; do
+    [[ -d "$d" ]] || continue
+    vim -es -u NONE -c "helptags $d" -c 'qa!' </dev/null >/dev/null 2>&1 \
+      || warn "helptags failed for $d"
+  done
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P10 — ssh key                                                              |
+# -----------------------------------------------------------------------------
+
+SSH_KEY_CREATED=0
+
+phase_ssh() {
+  step "ssh key"
+  local ssh_dir="$HOME/.ssh" email
+  mkdir -p "$ssh_dir"
+  chmod 700 "$ssh_dir"
+  # authorized_keys / known_hosts already exist here — never touch them.
+  if [[ -f "$ssh_dir/id_ed25519" ]]; then
+    say "  ok        $ssh_dir/id_ed25519 already exists"
+    return 0
+  fi
+  # `git config --get` exits 1 when unset, which would abort under `set -e`.
+  email="$(git config --get user.email || echo "$USER@$(hostname)")"
+  ssh-keygen -t ed25519 -C "$email" -f "$ssh_dir/id_ed25519" -N "" \
+    || { warn "ssh-keygen failed"; return 0; }
+  SSH_KEY_CREATED=1
+  # Deliberately not starting an ssh-agent here: on a server it just leaks an
+  # orphaned agent process that nothing will ever use.
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P11 — docker group                                                         |
+# -----------------------------------------------------------------------------
+
+phase_docker() {
+  step "docker group"
+  if ! getent group docker >/dev/null 2>&1; then
+    say "  no docker group (docker.io not installed?) — skipping"
+    return 0
+  fi
+  if id -nG "$USER" | tr ' ' '\n' | grep -Fx docker >/dev/null 2>&1; then
+    say "  ok        $USER is already in the docker group"
+    return 0
+  fi
+  say "  groups before: $(id -nG "$USER")"
+  require_sudo
+  # -aG, never -G. Plain -G *replaces* the supplementary group list and would
+  # drop this account from sudo and adm — unrecoverable on a headless box.
+  sudo usermod -aG docker "$USER" || { warn "usermod failed"; return 0; }
+  say "  groups after:  $(id -nG "$USER")"
+  say "  (takes effect after a full re-login, not in this session)"
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P12 — systemd user units                                                   |
+# -----------------------------------------------------------------------------
+
+phase_systemd() {
+  step "systemd user units"
+  if [[ -z "${XDG_RUNTIME_DIR:-}" ]] || ! systemctl --user show-environment >/dev/null 2>&1; then
+    warn "no systemd user bus in this environment — skipping daemon-reload"
+    return 0
+  fi
+  systemctl --user daemon-reload || warn "systemctl --user daemon-reload failed"
+  say "  daemon-reload done"
+  # NOT restarting claude-rc@* on purpose: that would kill any live
+  # `claude remote-control` session, and this script may well be running inside
+  # one of them.
+  local units
+  units="$(systemctl --user list-units --no-legend 'claude-rc@*' 2>/dev/null | awk '{print $1}' || true)"
+  if [[ -n "$units" ]]; then
+    say "  running claude-rc units (restart them yourself when convenient):"
+    printf '    %s\n' $units
+  fi
+
+  # Keep user units alive across logout.
+  if [[ "$(loginctl show-user "$USER" --property=Linger --value 2>/dev/null || echo no)" == "yes" ]]; then
+    say "  ok        lingering already enabled"
+  else
+    require_sudo
+    sudo loginctl enable-linger "$USER" || warn "could not enable lingering"
+  fi
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P13 — login shell                                                          |
+# -----------------------------------------------------------------------------
+
+CHSH_DONE=0
+
+zshrc_smoke_test() {
+  local zshrc="$REPO_DIR/zshrc-ubuntu" out
+  [[ -f "$zshrc" ]] || { warn "no zshrc-ubuntu in the repo"; return 1; }
+
+  if ! zsh -n "$zshrc"; then
+    warn "zshrc-ubuntu has a syntax error"
+    return 1
+  fi
+  say "  syntax ok"
+
+  # Run a real interactive login shell. SSH_TTY is cleared and NO_TMUX is set so
+  # the tmux auto-attach in zshrc cannot fire and hang this script.
+  if ! out="$(env -u SSH_TTY NO_TMUX=1 timeout 30 zsh -lic 'exit' </dev/null 2>&1)"; then
+    warn "an interactive zsh login shell failed to start:"
+    printf '%s\n' "$out" >&2
+    return 1
+  fi
+  say "  interactive login shell starts cleanly"
+  if [[ -n "$out" ]]; then
+    warn "zsh login printed output (not fatal, but you'll see this on every login):"
+    printf '%s\n' "$out" >&2
+  fi
+  return 0
+}
+
+phase_chsh() {
+  step "login shell"
+  local zsh_bin current
+  zsh_bin="$(command -v zsh || true)"
+  [[ -n "$zsh_bin" ]] || { warn "zsh is not installed — not changing the login shell"; return 0; }
+
+  current="$(getent passwd "$USER" | cut -d: -f7)"
+  if [[ "$current" == "$zsh_bin" ]]; then
+    say "  ok        login shell is already $zsh_bin"
+    CHSH_DONE=1
+    return 0
+  fi
+
+  if (( DO_CHSH == 0 )); then
+    say "  --no-chsh given; leaving login shell as $current"
+    return 0
+  fi
+
+  # This is the lockout guard. Do not change the login shell to something that
+  # cannot start.
+  if ! zshrc_smoke_test; then
+    warn "NOT changing the login shell: zshrc-ubuntu did not pass its smoke test."
+    warn "Fix it, then re-run setup-ubuntu.sh (or: chsh -s $zsh_bin)."
+    return 0
+  fi
+
+  grep -qxF "$zsh_bin" /etc/shells || {
+    require_sudo
+    sudo add-shell "$zsh_bin" || warn "could not register $zsh_bin in /etc/shells"
+  }
+
+  require_sudo
+  # Via sudo so it uses the cached credential instead of asking for the
+  # account password a second time.
+  if sudo chsh -s "$zsh_bin" "$USER"; then
+    say "  login shell changed to $zsh_bin"
+    CHSH_DONE=1
+  else
+    warn "chsh failed — login shell is still $current"
+  fi
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P14 — completions                                                          |
+# -----------------------------------------------------------------------------
+
+phase_completions() {
+  step "shell completions"
+  mkdir -p "$HOME/.zsh/completions"
+
+  if command -v ngrok >/dev/null 2>&1; then
+    ngrok completion > "$HOME/.zsh/completions/_ngrok" 2>/dev/null \
+      && say "  wrote ~/.zsh/completions/_ngrok" \
+      || warn "could not generate ngrok completions"
+  fi
+
+  command -v zsh >/dev/null 2>&1 || { warn "no zsh — skipping completion dump"; return 0; }
+
+  say "  pre-compiling the zsh completion dump"
+  # -f so this doesn't depend on ~/.zshrc. -i so compinit doesn't stop on an
+  # interactive compaudit prompt (umask here is 0002, so directories are
+  # group-writable and compaudit will always have something to say).
+  zsh -f <<'EOF' || warn "could not pre-compile the zsh completion dump"
+setopt null_glob
+COMPDUMP="${ZDOTDIR:-$HOME}/.zcompdump"
+fpath=("$HOME/.zsh/completions" $fpath)
+autoload -Uz compinit
+compinit -i -d "$COMPDUMP"
+zcompile -M "$COMPDUMP"
+chmod 644 "$COMPDUMP"*
+EOF
+  return 0
+}
+
+# -----------------------------------------------------------------------------
+# | P15 — summary                                                              |
+# -----------------------------------------------------------------------------
+
+print_summary() {
+  local rc=${1:-0} elapsed=$(( $(date +%s) - START_TS ))
+
+  printf '\n%s================================================================%s\n' "$C_GRN" "$C_OFF"
+  if (( rc == 0 )); then
+    say "Setup finished in $((elapsed / 60))m $((elapsed % 60))s."
+  else
+    printf '%sSetup stopped early (exit %s) after %sm %ss.%s\n' "$C_RED" "$rc" "$((elapsed / 60))" "$((elapsed % 60))" "$C_OFF"
+  fi
+  say "Log: $LOG_FILE"
+
+  if (( ${#WARNINGS[@]} )); then
+    printf '\n%sWarnings (%s):%s\n' "$C_YEL" "${#WARNINGS[@]}" "$C_OFF"
+    printf '  - %s\n' "${WARNINGS[@]}"
+  else
+    say ""
+    say "No warnings."
+  fi
+
+  if (( ${#BACKED_UP[@]} )); then
+    printf '\nFiles replaced (originals moved to %s):\n' "$BACKUP_DIR"
+    printf '  - %s\n' "${BACKED_UP[@]}"
+  fi
+
+  cat <<EOF
+
+Next steps
+----------
+1. Try the new shell WITHOUT logging out:
+
+       exec zsh -l
+
+   Then open a SECOND ssh session and confirm it logs in cleanly BEFORE you
+   close this one. If zsh is broken you can still get in with:
+
+       ssh $(hostname) -t /bin/bash        # then: chsh -s /bin/bash
+
+2. Fill in the API keys you actually use. Every file in ~/.keys/ is sourced at
+   each shell start, so an unedited placeholder gets exported as if it were a
+   real value — keep the export commented out until you paste a real one in.
+
+       ~/.keys/openai     OPENAI_API_KEY     (OPENAI_ORG_ID is optional)
+       ~/.keys/ngrok      NGROK_AUTHTOKEN
+
+       \$EDITOR ~/.keys/openai && source ~/.zshrc
+
+   Leave ~/.keys/anthropic commented out unless you specifically want API
+   billing: setting ANTHROPIC_API_KEY overrides Claude Code's subscription auth.
+
+3. Authenticate the tools that need it:
+
+       gh auth login                                  # interactive
+       ngrok config add-authtoken "\$NGROK_AUTHTOKEN"  # after step 2
+
+   In the gh prompts pick SSH as the Git protocol, and upload
+   ~/.ssh/id_ed25519.pub when it offers to — that registers this box with
+   GitHub in one pass. Authenticate with a web browser, NOT a pasted token:
+   only the browser flow requests the admin:public_key scope the upload needs,
+   and a token without it skips the upload silently. This box is headless, so
+   the browser launch fails and gh prints a one-time code instead — open
+   https://github.com/login/device on your Mac and enter it there.
+   Verify with:  ssh -T git@github.com
+
+   Do NOT run 'git lfs install' — ~/.gitconfig is a symlink into the repo and
+   it would dirty your working tree. The lfs filter is already configured.
+
+4. Restart Claude Code so it picks up the new ~/.claude/settings.json.
+
+5. Docker group membership needs a full re-login. Until then expect
+   "permission denied" on /var/run/docker.sock.
+
+6. Service restarts were suppressed during apt so nothing would kill a running
+   tmux or claude-rc session. When convenient:
+       sudo needrestart          # or just reboot
+
+7. tmux/vim clipboard goes over OSC 52 to your Mac. Enable it in iTerm2:
+   Settings -> General -> Selection -> "Applications in terminal may access
+   clipboard".
+EOF
+
+  if (( SSH_KEY_CREATED )); then
+    cat <<EOF
+
+8. A new SSH key was generated. Upload it via 'gh auth login' in step 3, or
+   paste the line below at https://github.com/settings/ssh/new
+
+EOF
+    cat "$HOME/.ssh/id_ed25519.pub" 2>/dev/null || :
+  fi
+  printf '%s================================================================%s\n' "$C_GRN" "$C_OFF"
+}
+
+# -----------------------------------------------------------------------------
+# | Run                                                                        |
+# -----------------------------------------------------------------------------
+
+trap cleanup EXIT
+trap 'exit 130' INT
+trap 'exit 143' TERM
+
+phase_sudo
+
+if (( SKIP_APT )); then
+  step "apt packages"
+  say "  --skip-apt given; skipping"
+else
+  phase_apt
+fi
+
+soft "shims"        phase_shims
+soft "starship"     phase_starship
+soft "fast-syntax-highlighting" phase_fsh
+soft "mise runtimes" phase_mise
+soft "pnpm"         phase_pnpm
+soft "key templates" phase_keys
+soft "symlinks"     phase_links
+soft "vim plugins"  phase_vim
+soft "ssh key"      phase_ssh
+soft "docker group" phase_docker
+soft "systemd"      phase_systemd
+soft "login shell"  phase_chsh
+soft "completions"  phase_completions
+
+exit 0

--- a/setup.sh
+++ b/setup.sh
@@ -3,6 +3,14 @@
 
 set -euo pipefail
 
+# macOS only — this script uses Homebrew, xcode-select, `defaults` and mas.
+# Without this guard a Linux run dies further down at the XCode Command Line
+# Tools check with a misleading error message.
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "setup.sh is for macOS. On Ubuntu/Debian, run ./setup-ubuntu.sh instead." >&2
+  exit 1
+fi
+
 echo "Starting system setup..."
 
 

--- a/systemd/claude-rc@.service
+++ b/systemd/claude-rc@.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Claude Code Remote Control (%i)
+
+[Service]
+Type=forking
+WorkingDirectory=%h/workspaces/claude-rc-projects/%i
+Environment=TERM=xterm-256color
+ExecStart=/usr/bin/tmux -L cc-%i new-session -d -s cc -x 200 -y 50 \
+  '%h/.local/bin/claude remote-control --remote-control-session-name-prefix %i'
+ExecStop=/usr/bin/tmux -L cc-%i kill-server
+Restart=always
+RestartSec=15
+
+[Install]
+WantedBy=default.target

--- a/tmux.conf-ubuntu
+++ b/tmux.conf-ubuntu
@@ -1,0 +1,71 @@
+# Ubuntu 24.04 (headless server) port of the sibling `tmux.conf`.
+# The macOS original lives next to this file as `tmux.conf`; structure, comments
+# and ordering are kept aligned so a diff between the two stays readable.
+# Only the clipboard section genuinely differs — see "Clipboard" below.
+
+# Keep Ctrl-a prefix (screen muscle memory)
+set -g prefix C-a
+unbind C-b
+bind a send-prefix
+
+# Proper color support — fixes zsh plugin issues
+# tmux-256color terminfo is present on Ubuntu 24.04 via the ncurses-base package
+# (/usr/share/terminfo/t/tmux-256color), so no local terminfo compile is needed.
+set -g default-terminal "tmux-256color"
+set -ag terminal-overrides ",xterm-256color:RGB"
+
+# Large scrollback
+set -g history-limit 50000
+
+# Mouse support
+# Tip: hold ⌥ Option while dragging in iTerm2 to suppress mouse reporting, so iTerm2
+# does its own local selection (handy across split panes, or inside a pager).
+# A normal drag goes through tmux copy-mode → OSC 52 → macOS clipboard.
+set -g mouse on
+
+# Window nav — both C-a n and C-a C-n work (screen muscle memory)
+bind n next-window
+bind C-n next-window
+bind p previous-window
+bind C-p previous-window
+
+# New window — both C-a c and C-a C-c work
+bind c new-window
+bind C-c new-window
+
+# Clipboard integration over OSC 52 (no pbcopy, no X11 on a headless box)
+#
+# macOS-side requirement: iTerm2 → Settings → General → Selection tab →
+#   ☑ "Applications in terminal may access clipboard"
+# Without that checkbox iTerm2 silently drops the OSC 52 and nothing is copied.
+#
+# `set-clipboard on` is load-bearing — do NOT weaken it to `external`.
+# Verified in tmux 3.4's input.c: input_osc_52() returns early unless the option is
+# exactly `on` (the enum is off=0, external=1, on=2). With `external`, tmux would still
+# set the outer clipboard from its OWN copy-mode, but it would silently discard OSC 52
+# sequences emitted by applications running inside a pane — which would break Vim's `vv`
+# mapping (vim-oscyank).
+set -g set-clipboard on
+setw -g mode-keys vi
+
+# Deliberately NOT setting `allow-passthrough`.
+# That option governs only the DCS wrapper escape hatch (\ePtmux;...\e\\), which passes
+# bytes through untouched. vim-oscyank sends a plain \e]52;c;<b64>\a, which tmux parses
+# in input_osc_52() and re-emits to the outer terminal via the `Ms` terminfo capability —
+# the intercept path, gated on `set-clipboard on`, not on `allow-passthrough`.
+# The intercept path is the one we want: it also populates a tmux paste buffer, so
+# `C-a P` pastes whatever Vim just yanked.
+
+# Copy mode → macOS clipboard via OSC 52
+# No pipe target needed — `set-clipboard on` makes tmux emit the OSC 52 itself.
+# MouseDragEnd1Pane uses copy-selection (no -and-cancel) on purpose, matching the
+# original's behavior of staying in copy mode after a drag.
+bind-key -T copy-mode-vi y                 send-keys -X copy-selection-and-cancel
+bind-key -T copy-mode-vi Enter             send-keys -X copy-selection-and-cancel
+bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-selection
+
+# Paste tmux buffer (Cmd+V from iTerm also works)
+bind P paste-buffer
+
+# Status bar (GNU date supports %H/%M)
+set -g status-right " #(date +%H:%M) "

--- a/vimrc-ubuntu
+++ b/vimrc-ubuntu
@@ -1,0 +1,453 @@
+" -----------------------------------------------------------------------------
+" |                       Ubuntu port of the macOS vimrc                      |
+" |                                                                           |
+" | This is the Ubuntu 24.04 (noble) headless-server port of the sibling      |
+" | file `vimrc` in this repo -- that one stays the macOS original and is     |
+" | left untouched. Every deliberate difference is tagged with an             |
+" | "UBUNTU:" comment, so `diff vimrc vimrc-ubuntu` reads as the changelog.   |
+" |                                                                           |
+" | Target: vim-nox 9.1.0016 (+ruby +python3 +perl +lua) but -clipboard       |
+" | and -xterm_clipboard, since Debian builds vim-nox --without-x. Driven     |
+" | over SSH from macOS iTerm2, usually inside tmux, so the system            |
+" | clipboard is reached with OSC 52 escapes (the vim-oscyank plugin)         |
+" | instead of the "+ register:                                               |
+" |   vv / 3vv = yank N lines to the Mac clipboard over OSC 52                |
+" |   ,y = OSC 52 yank operator (,yy = current line); ,y also in visual       |
+" -----------------------------------------------------------------------------
+
+" -----------------------------------------------------------------------------  
+" |                            VIM Settings                                   |
+" |                   (see gvimrc for gui vim settings)                       |
+" |                                                                           |
+" | Some highlights:                                                          |
+" |   jj = <esc>  Very useful for keeping your hands on the home row          |
+" |   ,n = toggle NERDTree off and on                                         |
+" |                                                                           |
+" |   ,f = fuzzy find all files                                               |
+" |   ,b = fuzzy find in all buffers                                          |
+" |   ,p = go to previous file                                                |
+" |                                                                           |
+" |   hh = inserts '=>'                                                       |
+" |   aa = inserts '@'                                                        |
+" |                                                                           |
+" |   ,h = new horizontal window                                              |
+" |   ,v = new vertical window                                                |
+" |                                                                           |
+" |   ,i = toggle invisibles                                                  |
+" |                                                                           |
+" |   enter and shift-enter = adds a new line after/before the current line   |
+" |                                                                           |
+" |   :call Tabstyle_tabs = set tab to real tabs                              |
+" |   :call Tabstyle_spaces = set tab to 2 spaces                             |
+" |                                                                           |
+" -----------------------------------------------------------------------------  
+
+set nocompatible
+
+let mapleader = ","
+" Professor VIM says '87% of users prefer jj over esc', jj abrams disagrees
+" UBUNTU: was `imap jj <Esc> ` -- note the TRAILING SPACE. :imap takes no "
+" comments and does not strip trailing whitespace, so the RHS was <Esc><Space>;
+" combined with `map <space> /` below, every jj dropped you at a search prompt.
+inoremap jj <Esc>
+
+" Tabs ************************************************************************
+"set sta " a <Tab> in an indent inserts 'shiftwidth' spaces
+
+function! Tabstyle_tabs()
+  " Using 4 column tabs
+  set softtabstop=4
+  set shiftwidth=4
+  set tabstop=4
+  set noexpandtab
+endfunction
+
+" function! Tabstyle_spaces()
+  " Use 2 spaces
+  set softtabstop=2
+  set shiftwidth=2
+  set tabstop=2
+  set expandtab
+" endfunction
+
+" why didn't this work?
+" call Tabstyle_spaces()
+
+
+" Indenting *******************************************************************
+set ai " Automatically set the indent of a new line (local to buffer)
+set si " smartindent (local to buffer)
+
+
+" Scrollbars ******************************************************************
+set sidescrolloff=2
+set numberwidth=4
+
+
+" Windows *********************************************************************
+set equalalways " Multiple windows, when created, are equal in size
+set splitbelow splitright
+
+" Vertical and horizontal split then hop to a new buffer
+" UBUNTU: the original had `:vsp^M^W^W<cr>`, where ^M ^W ^W are six LITERAL
+" ASCII characters (verified with od -c), not control codes -- so ,v failed
+" with "E492: Not an editor command: vsp^M^W^W". Spelled out properly here.
+:noremap <Leader>v :vsp<CR><C-w><C-w>
+:noremap <Leader>h :split<CR><C-w><C-w>
+
+
+" Cursor highlights ***********************************************************
+set cursorline
+"set cursorcolumn
+
+
+" Searching *******************************************************************
+set hlsearch  " highlight search
+set incsearch  " Incremental search, search as you type
+set ignorecase " Ignore case when searching 
+set smartcase " Ignore case when searching lowercase
+
+
+" Colors **********************************************************************
+" Harmless safety net; tmux/iTerm2 over SSH already report 256 colors
+set t_Co=256
+" Enable true color support - commented out due to screen compatibility issues
+" UBUNTU: still left off. ir_black is a 16-color cterm scheme, so termguicolors
+" buys nothing here, and the screen/tmux caveat above still applies.
+"let &t_8f = "\<Esc>[38;2;%lu;%lu;%lum"
+"let &t_8b = "\<Esc>[48;2;%lu;%lu;%lum"
+"set termguicolors
+set background=dark 
+syntax on " syntax highlighting
+colorscheme ir_black
+
+
+" Status Line *****************************************************************
+set showcmd
+set ruler " Show ruler
+"set ch=2 " Make command line two lines high
+
+
+" Line Wrapping ***************************************************************
+set nowrap
+set linebreak  " Wrap at word
+
+
+" Directories *****************************************************************
+" Setup backup location and enable
+"set backupdir=~/backup/vim
+"set backup
+
+" Set Swap directory
+"set directory=~/backup/vim/swap
+
+" Sets path to directory buffer was loaded from
+"autocmd BufEnter * lcd %:p:h
+
+
+" File Stuff ******************************************************************
+filetype plugin indent on
+" To show current filetype use: set filetype
+
+"autocmd FileType html :set filetype=xhtml
+
+
+" Insert New Line *************************************************************
+" awesome, inserts new line without going into insert mode
+" UBUNTU: the comment used to trail on the same line; :map takes no " comments,
+" so the comment text became part of the RHS and was replayed as normal-mode
+" keys. Moved above. Note also that a terminal cannot tell <S-Enter> from
+" <Enter> unless CSI-u / modifyOtherKeys is enabled (both send a bare CR), so
+" over SSH this mapping is effectively dead and only <Enter> below ever fires.
+map <S-Enter> O<ESC>
+map <Enter> o<ESC>
+"set fo-=r " do not insert a comment leader after an enter, (no work, fix!!)
+
+
+" Sessions ********************************************************************
+" Sets what is saved when you save a session
+set sessionoptions=blank,buffers,curdir,folds,help,resize,tabpages,winsize
+
+
+" Invisible characters *********************************************************
+set listchars=trail:.,tab:>-,eol:$
+set nolist
+" Toggle invisible chars
+" UBUNTU: comment moved off the mapping line -- :noremap takes no " comments
+:noremap <Leader>i :set list!<CR>
+
+" Line Numbers ***************************************************************
+map <Leader>s :set number!<CR>
+
+" Mouse ***********************************************************************
+"set mouse=a " Enable the mouse
+"behave xterm
+"set selectmode=mouse
+
+
+" Misc settings ***************************************************************
+set backspace=indent,eol,start
+set number " Show line numbers
+set matchpairs+=<:>
+set vb t_vb= " Turn off bell, this could be more annoying, but I'm not sure how
+set nofoldenable " Turn off folding 
+
+
+" Navigation ******************************************************************
+
+" Make cursor move by visual lines instead of file lines (when wrapping)
+map <up> gk
+map k gk
+imap <up> <C-o>gk
+map <down> gj
+map j gj
+imap <down> <C-o>gj
+map E ge
+" Use CTR to move between split windows
+map <C-J> <C-W>j
+map <C-K> <C-W>k
+map <C-H> <C-W>h
+map <C-L> <C-W>l
+" use space to search
+map <space> /
+" UBUNTU: <C-space> is usually not delivered as a distinct key through a
+" terminal (it arrives as NUL or nothing), so this one rarely fires over SSH
+map <C-space> ?
+
+" Go to previous file
+" UBUNTU: comment moved off the mapping line -- :map takes no " comments
+map <Leader>p <C-^>
+
+
+" Ruby stuff ******************************************************************
+"compiler ruby         " Enable compiler support for ruby
+"map <F5> :!ruby %<CR>
+" source: https://github.com/standardrb/standard/wiki/IDE:-vim
+let g:ruby_indent_assignment_style = 'variable'
+let g:ruby_indent_hanging_elements = 0
+
+
+" Omni Completion *************************************************************
+autocmd FileType html :set omnifunc=htmlcomplete#CompleteTags
+" UBUNTU: pythoncomplete# is the Python 2 completer and needs +python; this
+" build is -python +python3, so use the python3 one (present in the noble
+" runtime as /usr/share/vim/vim91/autoload/python3complete.vim)
+autocmd FileType python set omnifunc=python3complete#Complete
+autocmd FileType javascript set omnifunc=javascriptcomplete#CompleteJS
+autocmd FileType css set omnifunc=csscomplete#CompleteCSS
+autocmd FileType xml set omnifunc=xmlcomplete#CompleteTags
+autocmd FileType php set omnifunc=phpcomplete#CompletePHP
+autocmd FileType c set omnifunc=ccomplete#Complete
+" May require ruby compiled in
+" UBUNTU: this needs the vim-nox package (+ruby). Stock vim.basic is -ruby and
+" throws two errors on every ruby buffer before falling back to syntax
+" completion.
+autocmd FileType ruby,eruby set omnifunc=rubycomplete#Complete 
+" Note, this is matching the start of the filename, not the extension
+autocmd BufNewFile,BufRead .env* set filetype=sh
+
+" ZSH file handling
+autocmd FileType zsh set expandtab
+autocmd FileType zsh set tabstop=2
+autocmd FileType zsh set softtabstop=2
+autocmd FileType zsh set shiftwidth=2
+autocmd FileType zsh set autoindent
+autocmd FileType zsh set formatoptions+=r
+autocmd FileType zsh set formatoptions+=o
+autocmd FileType zsh set formatoptions+=j
+autocmd FileType zsh set commentstring=#\ %s
+
+
+" Hard to type *****************************************************************
+imap uu _
+imap hh =>
+imap aa @
+
+
+" -----------------------------------------------------------------------------  
+" |                              Plug-ins                                     |
+" -----------------------------------------------------------------------------  
+
+" NERDTree ********************************************************************
+:noremap <Leader>n :NERDTreeToggle<CR>
+let NERDTreeHijackNetrw=1 " User instead of Netrw when doing an edit /foobar
+let NERDTreeMouseMode=1 " Single click for everything
+let NERDTreeWinSize=40 " set default width of nerdtree
+
+
+" NERD Commenter **************************************************************
+let NERDCreateDefaultMappings=0 " I turn this off to make it simple
+
+" Toggle commenting on 1 line or all selected lines. Wether to comment or not
+" is decided based on the first line; if it's not commented then all lines
+" will be commented
+" :map <Leader>c :call NERDComment(0, "toggle")<CR><ESC>
+:map <Leader>c :call nerdcommenter#Comment(0, "toggle")<CR><ESC>
+" let g:NERDCreateDefaultMappings = 1
+
+" rails-vim ***************************************************************
+map <Leader>ra :AS<CR>
+map <Leader>rs :RS<CR>
+
+" AutoComplPop
+set completeopt=menu,longest,preview
+let g:AutoComplPop_IgnoreCaseOption = 0
+let g:AutoComplPop_BehaviorKeywordLength = 2
+set complete=.,w,b,u,t,k
+let g:AutoComplPop_CompleteOption = '.,w,b,u,t,k'
+" trying this behavior for a while
+inoremap <expr> <Tab> pumvisible() ? "\<C-n>" : "\<Tab>"
+inoremap <expr> <S-Tab> pumvisible() ? "\<C-p>" : "\<S-Tab>"
+" inoremap <Tab> <C-n>
+
+" -----------------------------------------------------------------------------  
+" |                             OS Specific                                   |
+" |                      (GUI stuff goes in gvimrc)                           |
+" -----------------------------------------------------------------------------  
+
+" Mac *************************************************************************
+"if has("mac") 
+  "" 
+"endif
+ 
+" Windows *********************************************************************
+"if has("gui_win32")
+  "" 
+"endif
+
+
+
+" -----------------------------------------------------------------------------  
+" |                               Startup                                     |
+" -----------------------------------------------------------------------------  
+" Open NERDTree on start
+" Never turn this on cause it opens on all the git commit/rebase stuff
+" autocmd VimEnter * exe 'NERDTree' | wincmd l 
+
+
+
+" -----------------------------------------------------------------------------  
+" |                               Host specific                               |
+" -----------------------------------------------------------------------------  
+" UBUNTU: the actual `source ~/.vimrc.local` moved to the very END of this file
+" (see below) so that host-specific overrides win over everything here. In the
+" macOS original it is sourced at this point, i.e. before the clipboard
+" mappings, the clipboard block and `set columns&`, so it could not override
+" any of them.
+
+"if hostname() == "foo"
+  " do something
+"endif
+
+" Example .vimrc.local:
+
+"call Tabstyle_tabs()
+"colorscheme ir_dark
+
+"autocmd User ~/git/some_folder/* call Tabstyle_spaces() | let g:force_xhtml=1
+
+" play nice with rvm https://rvm.beginrescueend.com/integration/vim/
+" removing as we are not using rvm anymore
+" set shell=/bin/sh
+
+" cause
+iabbrev busienss business
+iabbrev custmoer customer
+
+" -----------------------------------------------------------------------------
+" |                           Clipboard Mappings                               |
+" -----------------------------------------------------------------------------
+" UBUNTU: this host has no clipboard at all. vim-nox is built --without-x, so
+" has('clipboard'), has('clipboard_working') and has('unnamedplus') are all 0
+" and "+ is just an ordinary register that nothing ever reads. Vim 9.1.0016 in
+" noble also predates native OSC 52 (no 'clipmethod', no base64_encode(), no
+" pack/dist/opt/osc52) and an LTS will never rebase vim, so copying to the
+" Mac's clipboard goes through the vim-oscyank plugin: it emits an OSC 52
+" escape sequence that tmux and iTerm2 forward to macOS. setup-ubuntu.sh clones
+" it to ~/.vim/pack/vendor/start/vim-oscyank. Everything below degrades to a
+" plain register yank when the plugin is missing.
+let g:oscyank_silent = 1 " we print our own message
+
+" Map yy and vv to show their copy destinations, vv copies to system clipboard
+" nnoremap <expr> yy v:count ? v:count.'yy:echo "'.v:count.' lines copied to buffer"<CR>' : 'yy:echo "1 line copied to buffer"<CR>'
+nnoremap yy :<C-u>execute 'normal! '.v:count1.'yy' \| echon v:count1.' lines copied to buffer'<CR>
+
+" UBUNTU: vv used to be `<expr>` yanking into "+, which copies nowhere here.
+" Now: yank into the unnamed register (so p still works locally), then ship
+" that register out over OSC 52. Counts still behave -- vv = 1 line, 3vv = 3
+" lines. It is a function rather than a one-liner so the count is captured into
+" the argument up front: v:count is only dependable at the start of a mapping
+" (:h v:count) and :normal can reset it. (Plain yy above is an ordinary,
+" non-<expr> mapping, so its <CR> is translated as usual -- nothing to fix.)
+function! s:OscYankLines(n) abort
+  " silent so vim's own "N lines yanked" report does not stack with the echo
+  " below and force a hit-enter prompt once N is over 'report' (default 2)
+  silent execute 'normal! ' . a:n . 'yy'
+  if exists('*OSCYankRegister')
+    call OSCYankRegister('"')
+    echo a:n . (a:n > 1 ? ' lines' : ' line') . ' copied to system clipboard (OSC 52)'
+  else
+    echohl WarningMsg | echo 'vim-oscyank not installed; yanked to register only' | echohl NONE
+  endif
+endfunction
+
+nnoremap <silent> vv :<C-u>call <SID>OscYankLines(v:count1)<CR>
+
+" Operator and visual variants from the vim-oscyank README. ,y not ,c because
+" ,c is already NERDCommenter above. These are nmap/xmap on purpose (<Plug>
+" has to be resolved); if the plugin is absent the <Plug> is simply undefined,
+" so the mapping is an inert no-op rather than an error.
+nmap <leader>y  <Plug>OSCYankOperator
+nmap <leader>yy <leader>y_
+xmap <leader>y  <Plug>OSCYankVisual
+
+" Deliberately NOT using the README's TextYankPost autocmd recipe: it would
+" double-fire with the vv mapping above, and its default operator list includes
+" d, so every dd would clobber the Mac clipboard.
+
+" yank to clipboard
+" UBUNTU: dead code on this host (both has() checks are 0) -- kept, tightened with
+" clipboard_working, so the file still does the right thing under MacVim/gvim
+" or a real +clipboard build on an X11 box. Copying here is OSC 52's job.
+if has('clipboard') && has('clipboard_working')
+  set clipboard=unnamed " copy to the system clipboard
+
+  if has("unnamedplus") " X11 support
+    set clipboard+=unnamedplus
+  endif
+endif
+
+" source: https://github.com/standardrb/standard/wiki/IDE:-vim
+" packadd vim-lsp
+" Use standard if available
+if executable('standardrb')
+  au User lsp_setup call lsp#register_server({
+        \ 'name': 'standardrb',
+        \ 'cmd': ['standardrb', '--lsp'],
+        \ 'allowlist': ['ruby'],
+        \ })
+endif
+
+" UBUNTU: dropped `autocmd VimEnter * echom "Current colorscheme: " .
+" execute('colorscheme')`. execute() returns a string with a LEADING NEWLINE,
+" so the message was two lines tall in a one-line command area and triggered
+" "Press ENTER or type command to continue" on every single vim invocation --
+" including every git commit, git rebase -i and crontab -e. It was only debug
+" output, so it is gone rather than wrapped in trim().
+
+" -----------------------------------------------------------------------------
+" |                           General Preferences                             |
+" -----------------------------------------------------------------------------
+" UBUNTU: dropped `set columns&`, with nothing in its place. It resets 'columns'
+" to 80 and asks the terminal to resize via t_CWS, which inside a tmux pane over
+" SSH either resizes the user's pane down to 80 columns or leaves vim drawing
+" into an 80-column virtual screen. The pty already reports the real size.
+
+
+" -----------------------------------------------------------------------------
+" |                   Host specific (moved here from above)                   |
+" -----------------------------------------------------------------------------
+" UBUNTU: sourced LAST -- see the note in the Host specific section above.
+if filereadable(expand("~/.vimrc.local"))
+  source ~/.vimrc.local
+endif

--- a/zshrc-ubuntu
+++ b/zshrc-ubuntu
@@ -1,0 +1,298 @@
+# Ubuntu port of `zshrc` (24.04 noble, headless server).
+# The macOS original is the sibling file `zshrc` in this repo — keep the two in
+# sync: most edits should be made to BOTH files. Differences here are limited to
+# things that are genuinely macOS-only (Homebrew, BSD coreutils, /Applications).
+# This file becomes ~/.zshrc for the login shell, so nothing in it may hard-fail.
+
+# Profiling - Uncomment this section when profiling
+# zmodload zsh/zprof
+
+#typeset -F SECONDS
+#typeset -A _timing_starts
+
+#_start_timing() {
+  #echo "[timing] Starting $1..."
+  #_timing_starts[$1]=$SECONDS
+#}
+
+#_end_timing() {
+  #local end_time=$SECONDS
+  #local start_time=${_timing_starts[$1]}
+  #local init_time=${_timing_starts["ZSH Initialize"]}
+  #local section_elapsed=$(( end_time - start_time ))
+  #local total_elapsed=$(( end_time - init_time ))
+  #printf "[timing] %-20s %.1fs (total: %.1fs)\n" "$1:" $section_elapsed $total_elapsed
+#}
+
+# Environment Variables
+export EDITOR="vim"
+export VISUAL="$EDITOR"
+export PAGER=less
+export GIT_PAGER=less
+export LESS='-i -R'
+# Only promote a bare `xterm` to 256 colors, and only outside tmux/screen.
+# tmux sets TERM=tmux-256color and screen sets screen-256color; overwriting
+# those makes everything inside the multiplexer load the wrong terminfo.
+# Both terminfo entries exist here (ncurses-base), so nothing needs faking.
+if [[ -z "$TMUX" && -z "$STY" && "$TERM" == "xterm" ]]; then
+  export TERM='xterm-256color'
+fi
+export LC_CTYPE=en_US.UTF-8
+export LANG=en_US.UTF-8
+export SYSTEM_FILES_DIR="$HOME/workspaces/system_files"
+
+# Prevent NextJS from tracking
+# https://nextjs.org/telemetry
+# Fuck off Vercel!
+export NEXT_TELEMETRY_DISABLED=1
+
+# Path Configuration (consolidated)
+# ~/.local/bin is where the user-level tools live here: starship, bat, fd,
+# newrc, claude. typeset -U keeps the array deduplicated.
+typeset -U path
+path=(
+  $HOME/.local/bin
+  /usr/local/sbin
+  /usr/local/bin
+  $path
+)
+
+# mise — single version manager for ruby, python, node (replaces pyenv, fnm, RVM)
+# Guarded: this file is the login shell's ~/.zshrc, and an unconditional eval of
+# a missing binary is a lockout risk.
+command -v mise >/dev/null 2>&1 && eval "$(mise activate zsh)"
+
+# direnv — auto-activate/deactivate project envs on cd
+command -v direnv >/dev/null 2>&1 && eval "$(direnv hook zsh)"
+
+# Load service keys
+if [ -d "$HOME/.keys" ]; then
+  for f in $HOME/.keys/*; do
+    if [ -f "$f" ]; then
+      source "$f"
+    fi
+  done
+fi
+
+# History Configuration
+HISTSIZE=20000
+SAVEHIST=15000
+HISTFILE=$HOME/.history
+setopt EXTENDED_HISTORY HIST_EXPIRE_DUPS_FIRST HIST_VERIFY INC_APPEND_HISTORY
+
+# Directory Options
+setopt AUTO_CD AUTO_PUSHD PUSHD_IGNORE_DUPS AUTO_NAME_DIRS
+DIRSTACKSIZE=20
+
+# General Options
+setopt ALWAYS_TO_END NO_BEEP RM_STAR_WAIT
+autoload colors && colors
+
+# Key Bindings
+bindkey -v
+KEYTIMEOUT=1
+bindkey '^R' history-incremental-search-backward
+
+
+# Aliases
+alias py=python3
+# alias python=python3
+# Ubuntu 24.04 ships an externally-managed system python (PEP 668,
+# /usr/lib/python3.12/EXTERNALLY-MANAGED), so `pip install` outside a venv is
+# refused. Use a mise-managed python, a venv, or pipx.
+alias pip=pip3
+alias r=rails
+alias grep='nocorrect grep --color=auto'
+# GNU grep matches --exclude-dir against the directory *basename*, so the
+# macOS-era "./tmp"-style patterns silently excluded nothing. Bare names only.
+# (ripgrep — `rg` — is installed and is usually the better tool for this.)
+alias rgrep='nocorrect grep -inR --color=auto --exclude-dir={tmp,log,.git,node_modules,public,coverage} --exclude-dir=assets --exclude=".overmind.sock"'
+# GNU ls: -G means --no-group (it does NOT error, it just silently drops color
+# and the group column). Colour is --color=auto here.
+alias ls='ls --color=auto'
+alias l='ls'
+# ll expands the ls alias above, so it inherits --color=auto
+alias ll='ls -alh'
+alias pg='ps auxwww | grep'
+# procps-ng top wants the real field name; `-o cpu` is a hard error
+alias top='top -o %CPU'
+alias cpplint='find . -iname \*.h -o -iname \*.cpp -o -iname \*.c -o -iname \*.ino | xargs clang-format -i'
+alias reset_db='rake db:drop:all db:create db:migrate db:seed db:test:prepare'
+alias ae='deactivate &> /dev/null; source ./venv/bin/activate'
+alias de='deactivate'
+alias vi='vim'
+alias p='pnpm'
+# use only pnpm
+alias npm='echo "⚠️  Use pnpm instead!" && pnpm'
+
+
+# Utility Functions
+u() {
+  local ud="."
+  for i in {1..$1}; do ud="$ud/.."; done
+  cd $ud
+}
+
+chpwd() {
+  # Interactive only — otherwise every non-interactive `cd` (scripts, and
+  # Claude Code's Bash tool once zsh is the login shell) gets ls output
+  # injected into its stdout.
+  [[ -o interactive ]] || return
+  ls
+}
+
+bk() {
+  if [ -f "$1" ]; then
+    cp "$1" "$1.bk"
+  else
+    echo "File $1 does not exist"
+    return 1
+  fi
+}
+
+swap() {
+  if [ -f "$1" ] && [ -f "$2" ]; then
+    local tmpfile=$(mktemp)
+    mv "$1" "$tmpfile"
+    mv "$2" "$1"
+    mv "$tmpfile" "$2"
+  else
+    echo "Both files must exist"
+    return 1
+  fi
+}
+
+timestamp() {
+  # macOS used a BSD `date -j -f ...` round-trip of `date`; GNU date has no -j.
+  # Same number, far less ceremony.
+  date +%s
+}
+
+# No RUBY_CONFIGURE_OPTS block here: on Ubuntu ruby-build/mise find OpenSSL via
+# pkg-config from libssl-dev, and the macOS version shelled out to brew on every
+# shell start (printing an error when brew is absent).
+
+# Starship prompt (replaces zshrc.cmdprompt)
+command -v starship >/dev/null 2>&1 && eval "$(starship init zsh)"
+
+# Git Configuration
+# The `git config --global alias.ignore ...` line that lived here wrote to
+# ~/.gitconfig on every single shell start. setup-ubuntu.sh sets it once.
+
+# Screen title setting for terminal
+preexec () {
+    # tmux sets TERM=tmux-256color and screenrc sets screen-256color, so the
+    # old exact `== "screen"` test never matched.
+    case "$TERM" in
+        screen*|tmux*)
+            local CMD=${1[(wr)^(*=*|sudo|-*)]}
+            # \\\\ survives double-quote processing as \\, which print turns
+            # into the single backslash of the ESC-\ string terminator.
+            print -n "\ek$CMD\e\\\\"
+            ;;
+    esac
+}
+
+# (update_brewfile / check_brewfile_update lived here on macOS — dropped, along
+# with their BSD `stat -f %m`. Nothing on this box has a Homebrew to dump.)
+
+# ZSH Plugin and completion setup
+# Ubuntu's zsh already compiles /usr/share/zsh/vendor-completions,
+# /usr/share/zsh/vendor-functions and /usr/local/share/zsh/site-functions into
+# the default $fpath, so the Homebrew FPATH prepend has no replacement here.
+# ~/.zsh/completions is where setup-ubuntu.sh drops hand-installed completions
+# (e.g. _ngrok); a missing directory in $fpath is harmless.
+fpath=("$HOME/.zsh/completions" $fpath)
+
+    # Compile new completion dump
+    autoload -Uz compinit
+    compinit -C
+
+      # Git completion
+    zstyle ':completion:*:*:git-remote:*' group-order remote-groups aliases remote-tags remote-heads
+    zstyle ':completion:*:*:git-checkout:*' sort false
+    zstyle ':completion:*:*:git-switch:*' sort false
+
+    # Basic completion settings
+    zstyle ':completion:*' completer _complete _approximate _expand
+    zstyle ':completion:*' menu select
+    zstyle ':completion:*' max-errors 2
+
+    ## Case-insensitive completion
+    zstyle ':completion:*' matcher-list 'm:{[:lower:][:upper:]}={[:upper:][:lower:]}' 'm:{[:lower:][:upper:]}={[:upper:][:lower:]} l:|=* r:|=*'
+
+    #zstyle ':completion:*:default' list-prompt '%S%M matches%s'
+    #zstyle ':completion:*' file-sort modification reverse
+    zstyle ':completion:*' list-colors "=(#b) #([0-9]#)*=36=31"
+    #zstyle ':completion:*:manuals' separate-sections true
+
+
+   ## Enhanced completion settings
+   zstyle ':completion:*' special-dirs true
+   zstyle ':completion:*' squeeze-slashes true
+   zstyle ':completion:*:descriptions' format '%U%B%d%b%u'
+   zstyle ':completion:*:warnings' format '%BSorry, no matches for: %d%b'
+   zstyle ':completion:*:*:kill:*:processes' list-colors '=(#b) #([0-9]#)*=0=01;31'
+
+   # zsh-autosuggestions first — syntax highlighting has to come last so it can
+   # wrap the final set of ZLE widgets. Every source is guarded, so a missing
+   # plugin package is a no-op rather than a broken login.
+   [[ -r /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh ]] && source /usr/share/zsh-autosuggestions/zsh-autosuggestions.zsh
+
+   # Syntax highlighting (must be last). Prefer fast-syntax-highlighting if it
+   # has been cloned into ~/.zsh, otherwise the apt zsh-syntax-highlighting
+   # package. NEVER both: they share the _zsh_highlight* function namespace and
+   # would double-wrap the ZLE widgets.
+   # NOTE: the macOS original ends this source with `&!`, which backgrounds it
+   # into a subshell — the widget definitions die with that subshell, so the
+   # plugin has never actually loaded there either. Do not re-add the `&!`.
+   if [[ -r "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh" ]]; then
+     source "$HOME/.zsh/fast-syntax-highlighting/fast-syntax-highlighting.plugin.zsh"
+   elif [[ -r /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh ]]; then
+     source /usr/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh
+   fi
+
+# pnpm
+export PNPM_HOME="$HOME/.local/share/pnpm"
+# pnpm v11+ puts global binaries in $PNPM_HOME/bin; older layouts used
+# $PNPM_HOME itself. `typeset -U path` above handles dedup, so the macOS
+# case ":$PATH:" guard is unnecessary.
+path=(
+  $PNPM_HOME
+  $PNPM_HOME/bin
+  $path
+)
+# pnpm end
+
+# Auto-attach to tmux on SSH login.
+# Every guard has to hold:
+#   [[ -o interactive ]] — never touch scripts, `ssh host cmd`, scp/rsync/sftp
+#   -n $SSH_TTY          — only real SSH logins with a tty (not local/console)
+#   -z $TMUX             — already inside tmux; this also covers the claude-rc@
+#                          systemd tmux sessions, whose panes set $TMUX
+#   -z $CLAUDECODE       — Claude Code's Bash tool must never be exec'd away
+#   -z $NO_TMUX          — manual escape hatch
+#   command -v tmux      — never exec a binary that isn't installed
+# Bypass:  ssh ghost -t /bin/bash        (skips zsh entirely)
+#          NO_TMUX=1 ssh ghost           (needs SendEnv/AcceptEnv NO_TMUX)
+# -A attaches to session "main" if it exists and creates it otherwise.
+#
+# Deliberately NOT `exec tmux`: exec replaces this shell, so if the tmux server
+# ever fails to start you get logged straight back out with no way in short of
+# `ssh ghost -t /bin/bash`. Running it as a child and exiting only on success
+# costs one idle shell process and keeps a working prompt as the fallback.
+# Detaching (C-a d) still ends the SSH session, which is the point.
+if [[ -o interactive ]] &&
+   [[ -n "$SSH_TTY" ]] &&
+   [[ -z "$TMUX" ]] &&
+   [[ -z "$CLAUDECODE" ]] &&
+   [[ -z "$NO_TMUX" ]] &&
+   command -v tmux >/dev/null 2>&1; then
+  tmux new-session -A -s main && exit 0
+  print -u2 "tmux failed to start; continuing in a plain zsh shell."
+fi
+
+# Finish profiling
+# zprof
+
+


### PR DESCRIPTION
## What

Adds a parallel Ubuntu path alongside the existing macOS setup, for headless servers. `setup.sh` is macOS-only (Homebrew, `xcode-select`, `defaults`, mas), so this adds `setup-ubuntu.sh` + `aptfile-ubuntu` as the Ubuntu equivalents.

**The macOS path is unchanged** apart from an 8-line guard at the top of `setup.sh` — without it, a Linux run dies further down at the XCode Command Line Tools check with a misleading error.

## Approach

Strictly additive. Files that needed real changes get a `-ubuntu` sibling; files that were already portable are symlinked as-is and shared with the Mac.

| File | Why it differs |
|---|---|
| `zshrc-ubuntu` | GNU rather than BSD `ls`/`top`/`date`/`grep`; no Homebrew or `/Applications` on PATH; every `eval "$(x init …)"` guarded with `command -v`; tmux auto-attach on SSH |
| `vimrc-ubuntu` | Headless vim has no `+clipboard`, so copy goes over OSC 52 via `vim-oscyank` |
| `tmux.conf-ubuntu` | `pbcopy` → OSC 52 |
| `gitconfig-ubuntu` | Identical minus `core.hooksPath` — the AI `prepare-commit-msg` hook is deliberately not installed on the server |
| `claude/settings-ubuntu.json` | `$HOME`-relative statusline path plus `autoUpdatesChannel` |
| `bin/newrc`, `systemd/claude-rc@.service` | Linux-only; spin up a `claude remote-control` session under a systemd user unit |

Not ported: `Brewfile`, `Brewfile.mas`, `iterm2/`, `git_hooks/prepare-commit-msg`, `init.vim`.

`keys/bland` is dropped — that service is no longer used. It only ever held placeholder text.

## Two load-bearing details

- **`set -g set-clipboard on`** must stay `on`, not `external`. tmux only forwards an application's OSC 52 when the value is exactly `on`.
- **`usermod -aG`, never `-G`.** A bare `-G` would strip the account from `sudo`/`adm` — unrecoverable on a headless box.

## Safety properties of `setup-ubuntu.sh`

- Refuses to run as root, so it can't leave `$HOME` root-owned
- Phases are individually fail-soft; only "not Linux", "running as root", "repo missing", "sudo failed" and "zsh/git/curl absent after apt" abort the run
- Backs up anything it replaces to `~/.dotfiles-backup/<timestamp>/`, with the full run log
- Suppresses needrestart during apt, so a library upgrade can't restart `user@1000.service` and kill a running tmux or `claude-rc` session
- Smoke-tests the new zshrc (`zsh -n` plus a real interactive login) before touching the login shell, and prints the `ssh <host> -t /bin/bash` escape hatch

## Testing

Run end to end on Ubuntu 24.04.4 noble, x86_64, headless.

Verified: apt (63 packages), symlinks, mise runtimes (node 24.19.0 / python 3.14.7 / ruby 4.0.6), login shell change, vim, tmux auto-attach on SSH, docker, `gh auth`.

Still unverified: OSC 52 clipboard to the Mac pasteboard (needs the iTerm2 "Applications in terminal may access clipboard" setting), and a post-apt service restart / reboot.

## Follow-up

Several pre-existing bugs affect macOS too and are fixed only in the `-ubuntu` variants here, to keep this change additive: the `&!` that has prevented `fast-syntax-highlighting` from ever loading, `NEXT_TELEMETRY_DISABLED` missing `export`, literal `^M^W^W` breaking `,v`/`,h` with `E492`, trailing `"` comments on `imap jj` / `,i` / `,p`, `set columns&`, the `VimEnter` echo forcing a Press-ENTER prompt on every `git commit`, and `vim -u NONE … helptags ALL` tagging nothing. Worth a separate macOS-side PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)